### PR TITLE
feat: add applicationset git values

### DIFF
--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -146,6 +146,11 @@ func TestAccArgoCDApplicationSet_gitFiles(t *testing.T) {
 						"argocd_application_set.git_files",
 						"spec.0.generator.0.git.0.file.0.path",
 					),
+					resource.TestCheckResourceAttr(
+						"argocd_application_set.git_files",
+						"spec.0.generator.0.git.0.values.foo",
+						"bar",
+					),
 				),
 			},
 			{
@@ -820,6 +825,11 @@ func TestAccArgoCDApplicationSet_goTemplate(t *testing.T) {
 						"spec.0.go_template",
 						"true",
 					),
+					resource.TestCheckResourceAttr(
+						"argocd_application_set.go_template",
+						"spec.0.go_template_options.0",
+						"missingkey=error",
+					),
 				),
 			},
 			{
@@ -1115,6 +1125,9 @@ resource "argocd_application_set" "git_files" {
 				
 				file {
 					path = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+				}
+				values = {
+					foo = "bar"
 				}
 			} 
 		}
@@ -2721,6 +2734,9 @@ resource "argocd_application_set" "go_template" {
 		}
 
 		go_template = true
+		go_template_options = [
+			"missingkey=error"
+		]
 	
 		template {
 			metadata {

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -51,6 +51,12 @@ func applicationSetSpecSchemaV0() *schema.Schema {
 					Description: "Enable use of [Go Text Template](https://pkg.go.dev/text/template).",
 					Optional:    true,
 				},
+				"go_template_options": {
+					Type:        schema.TypeList,
+					Description: "Optional list of [Go Templating Options](https://pkg.go.dev/text/template#Template.Option).",
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
 				"strategy": {
 					Type:        schema.TypeList,
 					Description: "[Progressive Sync](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/) strategy",
@@ -332,6 +338,12 @@ func applicationSetGitGeneratorSchemaV0() *schema.Schema {
 					Optional:    true,
 					MaxItems:    1,
 					Elem:        applicationSetTemplateResource(true),
+				},
+				"values": {
+					Type:        schema.TypeMap,
+					Description: "Arbitrary string key-value pairs to pass to the template via the values field of the git generator.",
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
 			},
 		},

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -53,7 +53,7 @@ func applicationSetSpecSchemaV0() *schema.Schema {
 				},
 				"go_template_options": {
 					Type:        schema.TypeList,
-					Description: "Optional list of [Go Templating Options](https://pkg.go.dev/text/template#Template.Option).",
+					Description: "Optional list of [Go Templating Options](https://pkg.go.dev/text/template#Template.Option). Only relevant if `go_template` is true.",
 					Optional:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
@@ -340,7 +340,7 @@ func applicationSetGitGeneratorSchemaV0() *schema.Schema {
 					Elem:        applicationSetTemplateResource(true),
 				},
 				"values": {
-					Type:        schema.TypeMap,
+					Type:        schema.TypeSet,
 					Description: "Arbitrary string key-value pairs to pass to the template via the values field of the git generator.",
 					Optional:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -52,7 +52,7 @@ func applicationSetSpecSchemaV0() *schema.Schema {
 					Optional:    true,
 				},
 				"go_template_options": {
-					Type:        schema.TypeList,
+					Type:        schema.TypeSet,
 					Description: "Optional list of [Go Templating Options](https://pkg.go.dev/text/template#Template.Option). Only relevant if `go_template` is true.",
 					Optional:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},
@@ -340,7 +340,7 @@ func applicationSetGitGeneratorSchemaV0() *schema.Schema {
 					Elem:        applicationSetTemplateResource(true),
 				},
 				"values": {
-					Type:        schema.TypeSet,
+					Type:        schema.TypeMap,
 					Description: "Arbitrary string key-value pairs to pass to the template via the values field of the git generator.",
 					Optional:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -31,6 +31,10 @@ func expandApplicationSetSpec(d *schema.ResourceData, featureMultipleApplication
 
 	spec.GoTemplate = s["go_template"].(bool)
 
+	for _, k := range s["go_template_options"].([]interface{}) {
+		spec.GoTemplateOptions = append(spec.GoTemplateOptions, k.(string))
+	}
+
 	if v, ok := s["strategy"].([]interface{}); ok && len(v) > 0 {
 		spec.Strategy, err = expandApplicationSetStrategy(v[0].(map[string]interface{}))
 		if err != nil {
@@ -211,6 +215,10 @@ func expandApplicationSetGitGenerator(gg interface{}, featureMultipleApplication
 		}
 
 		asg.Git.Template = temp
+	}
+
+	if v, ok := g["values"]; ok {
+		asg.Git.Values = expandStringMap(v.(map[string]interface{}))
 	}
 
 	return asg, nil
@@ -937,9 +945,10 @@ func flattenApplicationSetSpec(s application.ApplicationSetSpec) ([]map[string]i
 	}
 
 	spec := map[string]interface{}{
-		"generator":   generators,
-		"go_template": s.GoTemplate,
-		"template":    flattenApplicationSetTemplate(s.Template),
+		"generator":           generators,
+		"go_template":         s.GoTemplate,
+		"go_template_options": s.GoTemplateOptions,
+		"template":            flattenApplicationSetTemplate(s.Template),
 	}
 
 	if s.Strategy != nil {
@@ -1044,6 +1053,7 @@ func flattenApplicationSetGitGenerator(gg *application.GitGenerator) []map[strin
 		"revision":          gg.Revision,
 		"path_param_prefix": gg.PathParamPrefix,
 		"template":          flattenApplicationSetTemplate(gg.Template),
+		"values":            gg.Values,
 	}
 
 	if len(gg.Directories) > 0 {

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -36,6 +36,7 @@ func expandApplicationSetSpec(d *schema.ResourceData, featureMultipleApplication
 		for _, opt := range opts {
 			spec.GoTemplateOptions = append(spec.GoTemplateOptions, opt.(string))
 		}
+	}
 
 	if v, ok := s["strategy"].([]interface{}); ok && len(v) > 0 {
 		spec.Strategy, err = expandApplicationSetStrategy(v[0].(map[string]interface{}))

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -31,9 +31,11 @@ func expandApplicationSetSpec(d *schema.ResourceData, featureMultipleApplication
 
 	spec.GoTemplate = s["go_template"].(bool)
 
-	for _, k := range s["go_template_options"].([]interface{}) {
-		spec.GoTemplateOptions = append(spec.GoTemplateOptions, k.(string))
-	}
+	if v, ok := s["go_template_options"]; ok {
+		opts := v.(*schema.Set).List()
+		for _, opt := range opts {
+			spec.GoTemplateOptions = append(spec.GoTemplateOptions, opt.(string))
+		}
 
 	if v, ok := s["strategy"].([]interface{}); ok && len(v) > 0 {
 		spec.Strategy, err = expandApplicationSetStrategy(v[0].(map[string]interface{}))

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -598,7 +598,7 @@ Required:
 Optional:
 
 - `go_template` (Boolean) Enable use of [Go Text Template](https://pkg.go.dev/text/template).
-- `go_template_options` (List of String) Optional list of [Go Templating Options](https://pkg.go.dev/text/template#Template.Option).
+- `go_template_options` (Set of String) Optional list of [Go Templating Options](https://pkg.go.dev/text/template#Template.Option). Only relevant if `go_template` is true.
 - `ignore_application_differences` (Block List) Application Set [ignoreApplicationDifferences](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#ignore-certain-changes-to-applications). (see [below for nested schema](#nestedblock--spec--ignore_application_differences))
 - `strategy` (Block List, Max: 1) [Progressive Sync](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/) strategy (see [below for nested schema](#nestedblock--spec--strategy))
 - `sync_policy` (Block List, Max: 1) Application Set [sync policy](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/). (see [below for nested schema](#nestedblock--spec--sync_policy))

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -598,6 +598,7 @@ Required:
 Optional:
 
 - `go_template` (Boolean) Enable use of [Go Text Template](https://pkg.go.dev/text/template).
+- `go_template_options` (List of String) Optional list of [Go Templating Options](https://pkg.go.dev/text/template#Template.Option).
 - `ignore_application_differences` (Block List) Application Set [ignoreApplicationDifferences](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#ignore-certain-changes-to-applications). (see [below for nested schema](#nestedblock--spec--ignore_application_differences))
 - `strategy` (Block List, Max: 1) [Progressive Sync](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/) strategy (see [below for nested schema](#nestedblock--spec--strategy))
 - `sync_policy` (Block List, Max: 1) Application Set [sync policy](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/). (see [below for nested schema](#nestedblock--spec--sync_policy))
@@ -1172,6 +1173,7 @@ Optional:
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--git--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
 
 <a id="nestedblock--spec--generator--git--directory"></a>
 ### Nested Schema for `spec.generator.git.directory`
@@ -2263,6 +2265,7 @@ Optional:
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--git--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
 
 <a id="nestedblock--spec--generator--matrix--generator--git--directory"></a>
 ### Nested Schema for `spec.generator.matrix.generator.git.directory`
@@ -3352,6 +3355,7 @@ Optional:
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--matrix--generator--git--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
 
 <a id="nestedblock--spec--generator--matrix--generator--matrix--generator--git--directory"></a>
 ### Nested Schema for `spec.generator.matrix.generator.matrix.generator.git.directory`
@@ -5484,6 +5488,7 @@ Optional:
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--merge--generator--git--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
 
 <a id="nestedblock--spec--generator--matrix--generator--merge--generator--git--directory"></a>
 ### Nested Schema for `spec.generator.matrix.generator.merge.generator.git.directory`
@@ -8660,6 +8665,7 @@ Optional:
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--git--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
 
 <a id="nestedblock--spec--generator--merge--generator--git--directory"></a>
 ### Nested Schema for `spec.generator.merge.generator.git.directory`
@@ -9749,6 +9755,7 @@ Optional:
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--matrix--generator--git--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
 
 <a id="nestedblock--spec--generator--merge--generator--matrix--generator--git--directory"></a>
 ### Nested Schema for `spec.generator.merge.generator.matrix.generator.git.directory`
@@ -11881,6 +11888,7 @@ Optional:
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--merge--generator--git--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
 
 <a id="nestedblock--spec--generator--merge--generator--merge--generator--git--directory"></a>
 ### Nested Schema for `spec.generator.merge.generator.merge.generator.git.directory`


### PR DESCRIPTION
### Changes
- add missing `values` field to to application_set [git generators](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Git/#pass-additional-key-value-pairs-via-values-field_1)
  - mostly based on the same implementation as used for cluster generators
- add missing `go_template_options` field to application_set [spec](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/applicationset-specification/)