### PR TITLE
Bump github.com/argoproj/argo-cd/v2 from 2.9.12 to 2.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/ProtonMail/gopenpgp/v2 v2.7.4
-	github.com/argoproj/argo-cd/v2 v2.11.0
+	github.com/argoproj/argo-cd/v2 v2.10.9
 	github.com/argoproj/gitops-engine v0.7.3
 	github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e
 	github.com/cristalhq/jwt/v3 v3.1.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/ProtonMail/gopenpgp/v2 v2.7.4
-	github.com/argoproj/argo-cd/v2 v2.9.12
+	github.com/argoproj/argo-cd/v2 v2.11.0
 	github.com/argoproj/gitops-engine v0.7.3
 	github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e
 	github.com/cristalhq/jwt/v3 v3.1.0


### PR DESCRIPTION
Hi, in order to use templatePatch we need to bump the argocd go lib to at least 2.10