### PR TITLE
feat: add support for customer argocd api server name

### DIFF
--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -124,6 +124,11 @@ func Provider() *schema.Provider {
 				Description: "Namespace name which should be used for port forwarding.",
 				Optional:    true,
 			},
+			"server_name": {
+				Type:        schema.TypeString,
+				Description: "The Argo CD API Server name (default \"argocd-server\")",
+				Optional:    true,
+			},
 			"headers": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -278,6 +283,7 @@ func argoCDProviderConfigFromResourceData(ctx context.Context, d *schema.Resourc
 		PlainText:                getBoolFromResourceData(d, "plain_text"),
 		PortForward:              getBoolFromResourceData(d, "port_forward"),
 		PortForwardWithNamespace: getStringFromResourceData(d, "port_forward_with_namespace"),
+		ServerName:               getStringFromResourceData(d, "server_name"),
 		ServerAddr:               getStringFromResourceData(d, "server_addr"),
 		UseLocalConfig:           getBoolFromResourceData(d, "use_local_config"),
 		UserAgent:                getStringFromResourceData(d, "user_agent"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ provider "argocd" {
 - `plain_text` (Boolean) Whether to initiate an unencrypted connection to ArgoCD server.
 - `port_forward` (Boolean) Connect to a random argocd-server port using port forwarding.
 - `port_forward_with_namespace` (String) Namespace name which should be used for port forwarding.
+- `server_name` (String) The Argo CD API Server name (default "argocd-server"). Only relevant when port forwarding.
 - `server_addr` (String) ArgoCD server address with port. Can be set through the `ARGOCD_SERVER` environment variable.
 - `use_local_config` (Boolean) Use the authentication settings found in the local config file. Useful when you have previously logged in using SSO. Conflicts with `auth_token`, `username` and `password`.
 - `user_agent` (String) User-Agent request header override.

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,8 +117,8 @@ provider "argocd" {
 - `plain_text` (Boolean) Whether to initiate an unencrypted connection to ArgoCD server.
 - `port_forward` (Boolean) Connect to a random argocd-server port using port forwarding.
 - `port_forward_with_namespace` (String) Namespace name which should be used for port forwarding.
-- `server_name` (String) The Argo CD API Server name (default "argocd-server"). Only relevant when port forwarding.
 - `server_addr` (String) ArgoCD server address with port. Can be set through the `ARGOCD_SERVER` environment variable.
+- `server_name` (String) The Argo CD API Server name (default "argocd-server")
 - `use_local_config` (Boolean) Use the authentication settings found in the local config file. Useful when you have previously logged in using SSO. Conflicts with `auth_token`, `username` and `password`.
 - `user_agent` (String) User-Agent request header override.
 - `username` (String) Authentication username. Can be set through the `ARGOCD_AUTH_USERNAME` environment variable.

--- a/internal/provider/model_provider.go
+++ b/internal/provider/model_provider.go
@@ -32,6 +32,7 @@ type ArgoCDProviderConfig struct {
 	ServerAddr               types.String `tfsdk:"server_addr"`
 	PortForward              types.Bool   `tfsdk:"port_forward"`
 	PortForwardWithNamespace types.String `tfsdk:"port_forward_with_namespace"`
+	ServerName               types.String `tfsdk:"server_name"`
 	Kubernetes               []Kubernetes `tfsdk:"kubernetes"`
 
 	// Run ArgoCD API server locally
@@ -68,6 +69,7 @@ func (p ArgoCDProviderConfig) getApiClientOptions(ctx context.Context) (*apiclie
 		PlainText:            p.PlainText.ValueBool(),
 		PortForward:          p.PortForward.ValueBool(),
 		PortForwardNamespace: p.PortForwardWithNamespace.ValueString(),
+		ServerName:           p.ServerName.ValueString(),
 		ServerAddr:           getDefaultString(p.ServerAddr, "ARGOCD_SERVER"),
 		UserAgent:            p.Username.ValueString(),
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -74,6 +74,10 @@ func (p *ArgoCDProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 				Description: "Namespace name which should be used for port forwarding.",
 				Optional:    true,
 			},
+			"server_name": schema.StringAttribute{
+				Description: "The Argo CD API Server name (default \"argocd-server\")",
+				Optional:    true,
+			},
 			"use_local_config": schema.BoolAttribute{
 				Description: "Use the authentication settings found in the local config file. Useful when you have previously logged in using SSO. Conflicts with `auth_token`, `username` and `password`.",
 				Optional:    true,


### PR DESCRIPTION
Fixes #231 as the API client now supports passing custom server names.

Honestly quite new to TF providers so not 100% sure how to test this, but codewise it's pretty straight forward wiring afaics.