### PR TITLE
feat: add support for `validate` option when provisioning/maintaining argocd applications

### DIFF
--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -43,6 +43,12 @@ func resourceArgoCDApplication() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 			},
+			"validate": {
+				Type:        schema.TypeBool,
+				Description: "Whether to validate the application spec before creating or updating the application.",
+				Optional:    true,
+				Default:     true,
+			},
 			"status": applicationStatusSchema(),
 		},
 		SchemaVersion: 4,
@@ -132,6 +138,7 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 		return featureNotSupported(features.ManagedNamespaceMetadata)
 	}
 
+	validate := d.Get("validate").(bool)
 	app, err := si.ApplicationClient.Create(ctx, &applicationClient.ApplicationCreateRequest{
 		Application: &application.Application{
 			ObjectMeta: objectMeta,
@@ -141,7 +148,9 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 				APIVersion: "argoproj.io/v1alpha1",
 			},
 		},
+		Validate: &validate,
 	})
+
 	if err != nil {
 		return argoCDAPIError("create", "application", objectMeta.Name, err)
 	} else if app == nil {
@@ -296,6 +305,7 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
+	validate := d.Get("validate").(bool)
 	if _, err = si.ApplicationClient.Update(ctx, &applicationClient.ApplicationUpdateRequest{
 		Application: &application.Application{
 			ObjectMeta: objectMeta,
@@ -305,6 +315,7 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 				APIVersion: "argoproj.io/v1alpha1",
 			},
 		},
+		Validate: &validate,
 	}); err != nil {
 		return argoCDAPIError("update", "application", objectMeta.Name, err)
 	}

--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -40,7 +40,7 @@ func TestAccArgoCDApplication(t *testing.T) {
 				ResourceName:            "argocd_application." + name,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 			{
 				// Update
@@ -87,7 +87,7 @@ func TestAccArgoCDApplication(t *testing.T) {
 				ResourceName:            "argocd_application." + name,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "validate"},
 			},
 		},
 	})
@@ -149,7 +149,7 @@ ingress:
 				ResourceName:            "argocd_application.helm",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -176,7 +176,10 @@ func TestAccArgoCDApplication_Kustomize(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccArgoCDApplicationKustomize(
-					acctest.RandomWithPrefix("test-acc")),
+					acctest.RandomWithPrefix("test-acc"),
+					"examples/helloWorld",
+					true,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"argocd_application.kustomize",
@@ -198,7 +201,7 @@ func TestAccArgoCDApplication_Kustomize(t *testing.T) {
 				ResourceName:            "argocd_application.kustomize",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -233,7 +236,7 @@ func TestAccArgoCDApplication_IgnoreDifferences(t *testing.T) {
 				ResourceName:            "argocd_application.ignore_differences",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "status", "validate"},
 			},
 			{
 				Config: testAccArgoCDApplicationIgnoreDiffJQPathExpressions(
@@ -259,7 +262,7 @@ func TestAccArgoCDApplication_IgnoreDifferences(t *testing.T) {
 				ResourceName:            "argocd_application.ignore_differences_jqpe",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "status", "validate"},
 			},
 		},
 	})
@@ -293,7 +296,7 @@ func TestAccArgoCDApplication_RevisionHistoryLimit(t *testing.T) {
 				ResourceName:            "argocd_application.revision_history_limit",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "status", "validate"},
 			},
 		},
 	})
@@ -322,7 +325,7 @@ func TestAccArgoCDApplication_OptionalDestinationNamespace(t *testing.T) {
 				ResourceName:            "argocd_application.no_namespace",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "status", "validate"},
 			},
 		},
 	})
@@ -407,7 +410,7 @@ func TestAccArgoCDApplication_DirectoryJsonnet(t *testing.T) {
 				ResourceName:            "argocd_application.directory",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -513,7 +516,7 @@ func TestAccArgoCDApplication_EmptyDirectory(t *testing.T) {
 				ResourceName:            "argocd_application.directory",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -545,7 +548,7 @@ func TestAccArgoCDApplication_DirectoryIncludeExclude(t *testing.T) {
 				ResourceName:            "argocd_application.directory",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -605,7 +608,7 @@ func TestAccArgoCDApplication_SyncPolicy(t *testing.T) {
 				ResourceName:            "argocd_application.sync_policy",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -957,7 +960,7 @@ func TestAccArgoCDApplication_CustomNamespace(t *testing.T) {
 				ResourceName:            "argocd_application.custom_namespace",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "status", "validate"},
 			},
 		},
 	})
@@ -991,7 +994,7 @@ func TestAccArgoCDApplication_MultipleSources(t *testing.T) {
 				ResourceName:            "argocd_application.multiple_sources",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -1029,7 +1032,7 @@ func TestAccArgoCDApplication_HelmValuesFromExternalGitRepo(t *testing.T) {
 				ResourceName:            "argocd_application.helm_values_external",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "status", "validate"},
 			},
 		},
 	})
@@ -1052,7 +1055,7 @@ func TestAccArgoCDApplication_ManagedNamespaceMetadata(t *testing.T) {
 				ResourceName:            "argocd_application.namespace_metadata",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version"},
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version", "validate"},
 			},
 		},
 	})
@@ -1078,6 +1081,42 @@ func TestAccArgoCDApplication_Wait(t *testing.T) {
 						"argocd_application."+name,
 						"spec.0.source.0.target_revision",
 						chartRevision,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccArgoCDApplication_Validate(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDApplicationKustomize(
+					acctest.RandomWithPrefix("test-acc"),
+					"path-does-not-exist",
+					true,
+				),
+				ExpectError: regexp.MustCompile("app path does not exist"),
+			},
+			{
+				Config: testAccArgoCDApplicationKustomize(
+					acctest.RandomWithPrefix("test-acc"),
+					"path-does-not-exist",
+					false,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_application.kustomize",
+						"validate",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_application.kustomize",
+						"spec.0.source.0.path",
+						"path-does-not-exist",
 					),
 				),
 			},
@@ -1219,7 +1258,7 @@ resource "argocd_application" "helm_file_parameters" {
 }`, name)
 }
 
-func testAccArgoCDApplicationKustomize(name string) string {
+func testAccArgoCDApplicationKustomize(name string, path string, validate bool) string {
 	return fmt.Sprintf(`
 resource "argocd_application" "kustomize" {
   metadata {
@@ -1233,7 +1272,7 @@ resource "argocd_application" "kustomize" {
   spec {
     source {
       repo_url        = "https://github.com/kubernetes-sigs/kustomize"
-      path            = "examples/helloWorld"
+      path            = "%s"
       target_revision = "release-kustomize-v3.7"
       kustomize {
   	    name_prefix  = "foo-"
@@ -1257,8 +1296,11 @@ resource "argocd_application" "kustomize" {
       namespace = "default"
     }
   }
+
+  validate = %t
+
 }
-	`, name)
+	`, name, path, validate)
 }
 
 func testAccArgoCDApplicationDirectoryNoPath(name string) string {

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -177,6 +177,7 @@ resource "argocd_application" "multiple_sources" {
 
 - `cascade` (Boolean) Whether to applying cascading deletion when application is removed.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `validate` (Boolean) Whether to validate the application spec before creating or updating the application.
 - `wait` (Boolean) Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will experience an expected timeout event if `wait = true`.
 
 ### Read-Only


### PR DESCRIPTION
resolves https://github.com/argoproj-labs/terraform-provider-argocd/issues/261
this PR adds `validate` (similar to `--validate` flag in argocd CLI) to `argocd_application` resource, to be able to skip(set it to false) the app validation. It is set to true by default.