### PR TITLE
ci: Fix GoReleaser config after repo move

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,10 +38,9 @@ release:
   draft: true
   disable: false
   github:
-    owner: oboukili
+    owner: argoproj-labs
     name: terraform-provider-argocd
 changelog:
-  skip: false
   filters:
     exclude:
       - '^docs:'


### PR DESCRIPTION
See failed Release action:
https://github.com/argoproj-labs/terraform-provider-argocd/actions/runs/11121825140/job/30901785438

> ```log
>       • upload failed                                request-id=3802:30B880:DCF2EC:EE58D2:66FBBA21 error=POST https://uploads.github.com/repos/oboukili/terraform-provider-argocd/releases/177753143/assets?name=terraform-provider-argocd_6.2.0_windows_amd64.zip: 307 Moved Permanently [] name=terraform-provider-argocd_6.2.0_windows_amd64.zip release-id=177753143
>       • failed to upload artifact, will retry        try=1 artifact=terraform-provider-argocd_6.2.0_windows_amd64.zip error=POST https://uploads.github.com/repos/oboukili/terraform-provider-argocd/releases/177753143/assets?name=terraform-provider-argocd_6.2.0_windows_amd64.zip: 307 Moved Permanently []
> ```