### PR TITLE
chore: Update stale config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,19 +1,33 @@
+## Reference: https://github.com/actions/stale
 name: 'Close stale Issues/PRs'
 on:
   schedule:
     - cron: '30 12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 14
+          days-before-stale: 60
           days-before-close: 10
           # Issue settings
-          stale-issue-message: 'This issue is stale because of a lack of response from the original author. Please provide the requested feedback or this will be closed in 10 days.'
-          any-of-issue-labels: 'answered,cannot-reproduce,invalid,needs-more-info'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          exempt-issue-labels: "on-hold,pinned,good first issue"
           # PR Settings
-          stale-pr-message: 'This pr is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          exempt-pr-labels: "on-hold,pinned"


### PR DESCRIPTION
Details:
- Reduce permissions of the GITHUB_TOKEN variable
- Action update v8 -> v9
- Increase stale days 14 -> 60
- Do not stale issues with labels "on-hold", "pinned" or "good first issue"