### PR TITLE
feat: add devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "name": "terraform-provider-argocd",
+  // officiall MS template from https://github.com/devcontainers/templates/tree/main/src/go
+  "image": "mcr.microsoft.com/devcontainers/go:1.21-bookworm",
+  "features": {
+    // https://github.com/devcontainers/features/tree/main/src/docker-in-docker
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "enableNonRootDocker": "false",
+      "disableIp6tables": true // experienced issues with missing chains in ip6tables when creating kind clusters
+    },
+    // https://github.com/devcontainers/features/tree/main/src/terraform
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.9.7" // omit for latest
+    },
+    // https://github.com/mpriscella/features/tree/main/src/kind
+    "ghcr.io/mpriscella/features/kind:1": {
+      "version": "v0.20.0" // omit for latest
+    },
+    // https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "1.27.11"
+    },
+    // https://github.com/rio/features/tree/main/src/kustomize
+    "ghcr.io/rio/features/kustomize:1": {},
+    // https://github.com/guiyomh/features/blob/main/src/goreleaser
+    "ghcr.io/guiyomh/features/goreleaser:0": {},
+    // https://github.com/audacioustux/devcontainers/tree/main/src/argo
+    "ghcr.io/audacioustux/devcontainers/argo:1": {
+      "argocd": "2.8.13" // omit if empty
+    }
+  },
+  "forwardPorts": [
+    8080 // the "hard-coded" port for forwarded argo-cd"
+  ],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "scripts/testacc_prepare_env.sh" // pre-create the kind cluster with argocd installed
+}


### PR DESCRIPTION
This adds a `devcontainer.json` file to the repo declaring as code the development environment needed to develop this provider. See [containers.dev](https://containers.dev) for the standard.

Helpful for users who want to quickly get started developing (e.g with Github Codespaces) or for users who like to offload their development workload to another machine using something like [devpod](https://devpod.sh).

I tested the image and did some coding using devpod, works like a charm. Might need slight updates in the future but I think It's a good v1 to work with.