### PR TITLE
ci: Don't always execute the long-running acceptance tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,14 @@
 name: Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+    - main
+    paths:
+    - "!README.md"
+    - "!CONTRIBUTING.md"
+    - "!.github/**"
+    - ".github/workflows/tests.yml"
 
 jobs:
   build:


### PR DESCRIPTION
We trigger CI way too much. Let's optimize it:
- Don't trigger on main branch (after a PR got merged)
  **Reason:** We enforce linear commits (contributors and maintainers need to have current CI run on the PR).
- Don't trigger CI when Dependabot updates other workflows
  > <img width="819" alt="image" src="https://github.com/user-attachments/assets/1126cc45-8734-4ab5-bc03-356e2aea1ea2">
- Don't trigger on README and CONTRIBUTING changes