### PR TITLE
ci: Fix deprecation warnings of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,12 +31,12 @@ linters:
     - goconst
     - gocritic
     - gofmt
-    - gomnd
     - gosimple
     - govet
     - ineffassign
     - makezero
     - misspell
+    - mnd
     - nakedret
     - nilerr
     - nolintlint
@@ -50,8 +50,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
-    - vetshadow
     - whitespace
     - wsl
 
@@ -59,7 +57,10 @@ linters-settings:
   dogsled:
     max-blank-identifiers: 3
   errcheck:
-    ignore: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set,fmt:.*,io:Close
+    exclude-functions:
+      - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set
+      - fmt:.*
+      - io:Close
   errorlint:
     errorf: false
   goconst:
@@ -73,31 +74,29 @@ linters-settings:
       - performance
       - experimental
       - opinionated
-  gomnd:
-    settings:
-      mnd:
-        checks:
-          - argument
-        ignored-functions:
-          # Terraform Plugin SDK
-          - resource.Retry
-          - schema.DefaultTimeout
-          - validation.*
-          # Terraform Plugin Framework
-          - int64validator.*
-          - listvalidator.*
-          - stringvalidator.*
-          - SetDefaultCreateTimeout
-          - SetDefaultReadTimeout
-          - SetDefaultUpdateTimeout
-          - SetDefaultDeleteTimeout
-          # Go
-          - make
-          - strconv.FormatFloat
-          - strconv.FormatInt
-          - strconv.ParseFloat
-          - strconv.ParseInt
-          - strings.SplitN
+  mnd:
+    checks:
+      - argument
+    ignored-functions:
+      # Terraform Plugin SDK
+      - resource.Retry
+      - schema.DefaultTimeout
+      - validation.*
+      # Terraform Plugin Framework
+      - int64validator.*
+      - listvalidator.*
+      - stringvalidator.*
+      - SetDefaultCreateTimeout
+      - SetDefaultReadTimeout
+      - SetDefaultUpdateTimeout
+      - SetDefaultDeleteTimeout
+      # Go
+      - make
+      - strconv.FormatFloat
+      - strconv.FormatInt
+      - strconv.ParseFloat
+      - strconv.ParseInt
+      - strings.SplitN
   nolintlint:
     allow-unused: false
     allow-leading-space: false


### PR DESCRIPTION
This PR fixes these deprecation warnings:

```bash
$ golangci-lint-1.59.1 run
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
WARN [config_reader] The configuration option `linters.gomnd.settings` is deprecated. Please use the options `linters.gomnd.checks`,`linters.gomnd.ignored-numbers`,`linters.gomnd.ignored-files`,`linters.gomnd.ignored-functions`.
WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet.
WARN [lintersdb] The name "vetshadow" is deprecated. The linter has been renamed to: govet.
WARN The linter 'gomnd' is deprecated (since v1.58.0) due to: The linter has been renamed. Replaced by mnd.
```

**Note for reviewers:**
- Disable whitespace diff :)
  > ![image](https://github.com/user-attachments/assets/cdb9b06d-884a-46d7-83d8-7ede6b2f090e)
