### PR TITLE
Fix: Extend policy validation to support update and delete actions

### DIFF
--- a/argocd/utils.go
+++ b/argocd/utils.go
@@ -87,7 +87,7 @@ func isValidPolicyAction(action string) bool {
 		"*":                       true,
 	}
 	validActionPatterns := []*regexp.Regexp{
-		regexp.MustCompile("action/.*"),
+		regexp.MustCompile("(action|update|delete)/.*"),
 	}
 
 	if validActions[action] {


### PR DESCRIPTION
This fix enhances the policy validation function to support the update and delete actions, in addition to the previously supported action keyword.

Per the documentation on [Fine-grained Permissions for update/delete actions](https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#fine-grained-permissions-for-updatedelete-action), the update and delete actions allow users to perform operations on an application and all of its resources. Additionally, these actions can be scoped to specific resources using the ``` <action>/<group>/<kind>/<ns>/<name> ``` format.

To align with this functionality, the regex used in policy validation has been updated to recognize update and delete as valid actions. This ensures that policies leveraging fine-grained permissions for update and delete are now properly validated.