### PR TITLE
feat(tests): align workflow file with framework skaffold repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: Import GPG key
       id: import_gpg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,51 +4,60 @@ name: Tests
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'README.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'README.md'
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
     - name: Set up Go
       uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
       with:
         go-version-file: 'go.mod'
-      id: go
-      
+        cache: true
+    - name: Build provider
+      run: make build
     - name: Run linters
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
       with:
         version: v1.59.1
 
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Go
+      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+      with:
+        go-version-file: 'go.mod'
+        cache: true
     # We need the latest version of Terraform for our documentation generation to use
     - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       name: Setup Terraform
       with:
         terraform_wrapper: false
-
     - name: Generate
       run: make generate
-
     - name: Confirm no diff
       run: |
         git diff --compact-summary --exit-code || \
-          (echo "*** Unexpected differences after code generation. Run 'make generate' and commit."; exit 1)
+          (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
           
-    - name: Build
-      run: make build
-
   acceptance_tests:
     name: Acceptance Tests
-    needs: build
+    needs: 
+    - build
+    - generate
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -58,23 +67,20 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: 'go.mod'
           check-latest: true
-
+          cache: true
       - name: Install Kustomize
         run: |
           curl -sL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
           chmod +x ./kustomize
-
       - name: Install Kind 0.24.0
         run: |
           curl -sLo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-$(uname)-amd64
           chmod +x ./kind
-
       - name: Set up ArgoCD ${{ matrix.argocd_version }}
         env:
           ARGOCD_VERSION: ${{ matrix.argocd_version }}
@@ -83,7 +89,6 @@ jobs:
           sh scripts/testacc_prepare_env.sh
           until $(nc -z 127.0.0.1 8080); do sleep 2;done
           netstat -tulpn
-
       - name: Run acceptance tests
         env:
           ARGOCD_VERSION: ${{ matrix.argocd_version }}


### PR DESCRIPTION
I tried to align the test/release file with the upstream https://github.com/hashicorp/terraform-provider-scaffolding-framework repo.

This changes the following:
- go installation is cached
- README.md changes don't trigger a testrun
- generate and build are two separate jobs that can run in parallel (but both block the acceptance_tests from running)

Relates to #440 