### PR TITLE
feat: use pinned terraform versions in testing matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         argocd_version: ["v2.10.18", "v2.11.12", "v2.12.8"]
+        terraform_version: ["1.4.*"]
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -73,6 +74,11 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true
           cache: true
+      - name: Setup Terraform ${{ matrix.terraform_version }}
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform_version }}
+          terraform_wrapper: false
       - name: Install Kustomize
         run: |
           curl -sL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash


### PR DESCRIPTION
Currently we use the "latest" terraform binary available in the Github runner. This is unpredictable and causes tests to suddenly be unstable if Terraform changes something from one minor version to another (as they likely did from 1.3 to 1.4, read https://github.com/runatlantis/atlantis/issues/2242).

Currently we only test one Terraform version. This change keeps this behavior but allows for multiple version testing in the future, in case we want this.