### PR TITLE
ci: Separate go mod download from acc test step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,8 @@ jobs:
           make testacc_prepare_env
           until $(nc -z 127.0.0.1 8080); do sleep 2;done
           netstat -tulpn
+      - name: Download go deps for tests
+        run: go mod download
       - name: Run acceptance tests
         env:
           ARGOCD_VERSION: ${{ matrix.argocd_version }}


### PR DESCRIPTION
scaffolding repo does this: https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/test.yml#L81C5-L81C29

Helps separating some logs from the test logs due to being another step.