### PR TITLE
feat: update to go 1.24

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "terraform-provider-argocd",
   // officiall MS template from https://github.com/devcontainers/templates/tree/main/src/go
-  "image": "mcr.microsoft.com/devcontainers/go:1.21-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/go:1.24-bookworm",
   "features": {
     // https://github.com/devcontainers/features/tree/main/src/docker-in-docker
     "ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -331,7 +331,7 @@ func TestAccArgoCDCluster_outsideDeletion(t *testing.T) {
 					if err != nil {
 						t.Error(fmt.Errorf("failed to get server interface: %s", err.Error()))
 					}
-					ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+					ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
 					defer cancel()
 					_, err = si.ClusterClient.Delete(ctx, &cluster.ClusterQuery{Name: clusterName})
 					if err != nil {

--- a/argocd/schema_application_test.go
+++ b/argocd/schema_application_test.go
@@ -1,7 +1,6 @@
 package argocd
 
 import (
-	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -51,7 +50,7 @@ func TestUpgradeSchemaApplication_V0V1_Default_SkipCrds(t *testing.T) {
 		},
 	}
 
-	actual, _ := resourceArgoCDApplicationStateUpgradeV0(context.TODO(), v0, nil)
+	actual, _ := resourceArgoCDApplicationStateUpgradeV0(t.Context(), v0, nil)
 
 	if !reflect.DeepEqual(v1, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)
@@ -77,7 +76,7 @@ func TestUpgradeSchemaApplication_V0V1_Default_SkipCrds_NoChange(t *testing.T) {
 		},
 	}
 
-	actual, _ := resourceArgoCDApplicationStateUpgradeV0(context.TODO(), v0, nil)
+	actual, _ := resourceArgoCDApplicationStateUpgradeV0(t.Context(), v0, nil)
 
 	if !reflect.DeepEqual(v0, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v0, actual)
@@ -108,7 +107,7 @@ func TestUpgradeSchemaApplication_V1V2_Default_NoChange(t *testing.T) {
 		},
 	}
 
-	actual, _ := resourceArgoCDApplicationStateUpgradeV1(context.TODO(), v1, nil)
+	actual, _ := resourceArgoCDApplicationStateUpgradeV1(t.Context(), v1, nil)
 
 	if !reflect.DeepEqual(v1, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)
@@ -140,7 +139,7 @@ func TestUpgradeSchemaApplication_V1V2_WithKsonnet(t *testing.T) {
 		},
 	}
 
-	_, err := resourceArgoCDApplicationStateUpgradeV1(context.TODO(), v1, nil)
+	_, err := resourceArgoCDApplicationStateUpgradeV1(t.Context(), v1, nil)
 
 	if err == nil || !strings.Contains(err.Error(), "'ksonnet' support has been removed") {
 		t.Fatalf("\n\nexpected error during state migration was not found - err returned was: %v", err)
@@ -177,7 +176,7 @@ func TestUpgradeSchemaApplication_V2V3_Default_NoChange(t *testing.T) {
 		},
 	}
 
-	actual, _ := resourceArgoCDApplicationStateUpgradeV2(context.TODO(), v2, nil)
+	actual, _ := resourceArgoCDApplicationStateUpgradeV2(t.Context(), v2, nil)
 
 	if !reflect.DeepEqual(v2, actual) {
 		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v2, actual)
@@ -550,7 +549,7 @@ func TestUpgradeSchemaApplication_V3V4(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actualState, err := resourceArgoCDApplicationStateUpgradeV3(context.TODO(), tc.sourceState, nil)
+			actualState, err := resourceArgoCDApplicationStateUpgradeV3(t.Context(), tc.sourceState, nil)
 			if err != nil {
 				t.Fatalf("error migrating state: %s", err)
 			}

--- a/argocd/schema_project_test.go
+++ b/argocd/schema_project_test.go
@@ -1,7 +1,6 @@
 package argocd
 
 import (
-	"context"
 	"reflect"
 	"testing"
 )
@@ -131,7 +130,7 @@ func TestResourceArgoCDProjectStateUpgradeV0(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actualState, err := resourceArgoCDProjectStateUpgradeV0(context.TODO(), tc.sourceState, nil)
+			actualState, err := resourceArgoCDProjectStateUpgradeV0(t.Context(), tc.sourceState, nil)
 			if err != nil {
 				t.Fatalf("error migrating state: %s", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj-labs/terraform-provider-argocd
 
-go 1.22.7
+go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.22.7
+go 1.24
 
 require github.com/hashicorp/terraform-plugin-docs v0.21.0
 


### PR DESCRIPTION
This updates the used go version to `1.24`, matching the go version used in Argo CD and dependencies (example would be #575).

Our CI will pick the new version automatically since it reads `go.mod`. 


Closes #582 