### PR TITLE
feat: remove remyoudompheng/bigfft lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -297,9 +297,6 @@ replace (
 
 	github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.16.0
 
-	// Apple Silicon support https://github.com/argoproj-labs/terraform-provider-argocd/pull/222
-	github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa
-
 	// Avoid CVE-2022-28948
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
Alternative to #592 proofing that the library is not needed anywhere and kept in the go.mod file due to a `replace` directive, thus `go mod tidy` won't remove it.

```console
$ grep -R "remyoudompheng/bigfft"     
# shows no results
```