### PR TITLE
feat: remove go-check/check lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -289,9 +289,6 @@ require (
 )
 
 replace (
-	// https://github.com/golang/go/issues/33546#issuecomment-519656923
-	github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
-
 	// https://github.com/argoproj/notifications-engine/pull/265
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 => github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf
 


### PR DESCRIPTION
Alternative to #591  proofing that the library is not needed anywhere and kept in the go.mod file due to a `replace` directive, thus `go mod tidy` won't remove it.

```console
$ grep -R "go-check/check"     
# shows no results
```