### PR TITLE
Skip managed_namespace_metadata if type-conversion fails due to nil

### DIFF
--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -469,15 +469,16 @@ func expandApplicationSyncPolicy(sp interface{}) (*application.SyncPolicy, error
 	}
 
 	if _mnm, ok := p["managed_namespace_metadata"].([]interface{}); ok && len(_mnm) > 0 {
-		mnm := _mnm[0].(map[string]interface{})
-		syncPolicy.ManagedNamespaceMetadata = &application.ManagedNamespaceMetadata{}
+		if mnm, ok := _mnm[0].(map[string]interface{}); ok {
+			syncPolicy.ManagedNamespaceMetadata = &application.ManagedNamespaceMetadata{}
 
-		if a, ok := mnm["annotations"]; ok {
-			syncPolicy.ManagedNamespaceMetadata.Annotations = expandStringMap(a.(map[string]interface{}))
-		}
+			if a, ok := mnm["annotations"]; ok {
+				syncPolicy.ManagedNamespaceMetadata.Annotations = expandStringMap(a.(map[string]interface{}))
+			}
 
-		if l, ok := mnm["labels"]; ok {
-			syncPolicy.ManagedNamespaceMetadata.Labels = expandStringMap(l.(map[string]interface{}))
+			if l, ok := mnm["labels"]; ok {
+				syncPolicy.ManagedNamespaceMetadata.Labels = expandStringMap(l.(map[string]interface{}))
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #492

The [reproduce-snippet](https://github.com/argoproj-labs/terraform-provider-argocd/issues/492#issuecomment-2495541373) I posted in the issue passed an object down into the code but eventually turned out to be `interface{} nil` causing a type-conversion panic because the second type-conversion isn't catched.

This fixes it by checking if the type-conversion worked, similar to the first one before proceeding.

For the reproduce-snippet that means the labels aren't applied at all because this for_each loop in itself seems incorrect.

No changes for everyone using the field like so:
```hcl
sync_policy {
  managed_namespace_metadata {
    labels = {
      foo = "bar"
    }
  }
}
```
This getts applied correctly.