### PR TITLE
fix(repository): specify AppProject for read/delete operations

### DIFF
--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -85,6 +85,7 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	tokenMutexConfiguration.RLock()
 	r, err := si.RepositoryClient.Get(ctx, &repository.RepoQuery{
 		Repo:         d.Id(),
+		AppProject:   d.State().Attributes["project"],
 		ForceRefresh: true,
 	})
 	tokenMutexConfiguration.RUnlock()
@@ -155,7 +156,7 @@ func resourceArgoCDRepositoryDelete(ctx context.Context, d *schema.ResourceData,
 	tokenMutexConfiguration.Lock()
 	_, err := si.RepositoryClient.DeleteRepository(
 		ctx,
-		&repository.RepoQuery{Repo: d.Id()},
+		&repository.RepoQuery{Repo: d.Id(), AppProject: d.State().Attributes["project"]},
 	)
 	tokenMutexConfiguration.Unlock()
 


### PR DESCRIPTION
Fixes #597 

The repo can exist globally or within an AppProject, therefore read/delete operations should specify the AppProject in the `RepoQuery`. 

If the project is empty the field turns into an empty string which is interpreted as "global" by Argo CD.