### PR TITLE
chore(golangci-lint): migrate to v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Build provider
       run: make build
     - name: Run linters
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        version: v1.64.6
+        version: v2.1.5
 
   generate:
     runs-on: ubuntu-24.04

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,6 @@
-issues:
-  exclude-rules:
-    - linters:
-        - paralleltest
-      text: "Function TestAcc"
-    - linters:
-        - tparallel
-      text: "TestAcc"
-    - linters:
-        - unparam
-      text: "always receives"
-    - path: _test\.go
-      linters:
-        - contextcheck
-  max-same-issues: 0
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -29,8 +14,6 @@ linters:
     - errorlint
     - goconst
     - gocritic
-    - gofmt
-    - gosimple
     - govet
     - ineffassign
     - makezero
@@ -42,75 +25,117 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - stylecheck
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usetesting
     - whitespace
     - wsl
-
-linters-settings:
-  dogsled:
-    max-blank-identifiers: 3
-  errcheck:
-    exclude-functions:
-      - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set
-      - fmt:.*
-      - io:Close
-  errorlint:
-    errorf: false
-  goconst:
-    ignore-tests: true
-    min-occurrences: 6
-  gocritic:
-    enabled-tags:
-      - diagnostic
-    disabled-tags:
-      - style
-      - performance
-      - experimental
-      - opinionated
-  mnd:
-    checks:
-      - argument
-    ignored-functions:
-      # Terraform Plugin SDK
-      - resource.Retry
-      - schema.DefaultTimeout
-      - validation.*
-      # Terraform Plugin Framework
-      - int64validator.*
-      - listvalidator.*
-      - stringvalidator.*
-      - SetDefaultCreateTimeout
-      - SetDefaultReadTimeout
-      - SetDefaultUpdateTimeout
-      - SetDefaultDeleteTimeout
-      # Go
-      - make
-      - strconv.FormatFloat
-      - strconv.FormatInt
-      - strconv.ParseFloat
-      - strconv.ParseInt
-      - strings.SplitN
-  nolintlint:
-    allow-unused: false
-    require-explanation: true
-    require-specific: true
-    allow-no-explanation:
-      - gomnd
-      - paralleltest
-      - tparallel
-      - unparam
-  predeclared:
-    ignore: cap,close,copy,delete,len,new
-  staticcheck:
-    checks: ["all", "-SA1019"]
-  stylecheck:
-    checks: ["all", "-ST1005", "-ST1003"]
-
-run:
-  timeout: 5m
+  settings:
+    dogsled:
+      max-blank-identifiers: 3
+    errcheck:
+      exclude-functions:
+        - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set
+        - fmt:.*
+        - io:Close
+    errorlint:
+      errorf: false
+    goconst:
+      min-occurrences: 6
+    gocritic:
+      enabled-tags:
+        - diagnostic
+      disabled-tags:
+        - style
+        - performance
+        - experimental
+        - opinionated
+    mnd:
+      checks:
+        - argument
+      ignored-functions:
+        - resource.Retry
+        - schema.DefaultTimeout
+        - validation.*
+        - int64validator.*
+        - listvalidator.*
+        - stringvalidator.*
+        - SetDefaultCreateTimeout
+        - SetDefaultReadTimeout
+        - SetDefaultUpdateTimeout
+        - SetDefaultDeleteTimeout
+        - make
+        - strconv.FormatFloat
+        - strconv.FormatInt
+        - strconv.ParseFloat
+        - strconv.ParseInt
+        - strings.SplitN
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-no-explanation:
+        - gomnd
+        - paralleltest
+        - tparallel
+        - unparam
+      allow-unused: false
+    predeclared:
+      ignore:
+        - cap
+        - close
+        - copy
+        - delete
+        - len
+        - new
+    staticcheck:
+      checks:
+        - -SA1019
+        - -ST1005
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - paralleltest
+        text: Function TestAcc
+      - linters:
+          - tparallel
+        text: TestAcc
+      - linters:
+          - unparam
+        text: always receives
+      - linters:
+          - contextcheck
+        path: _test\.go
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+      - linters:
+          - staticcheck
+        text: "ST1003:"
+      - linters:
+        - staticcheck
+        text: "SA1019:"
+        path: internal/types/pgp_public_key.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -682,9 +682,9 @@ func getInternalRestConfig() (*rest.Config, error) {
 			authInfo := cfg.AuthInfos[key]
 			rc.Host = cluster.Server
 			rc.ServerName = cluster.TLSServerName
-			rc.TLSClientConfig.CAData = cluster.CertificateAuthorityData
-			rc.TLSClientConfig.CertData = authInfo.ClientCertificateData
-			rc.TLSClientConfig.KeyData = authInfo.ClientKeyData
+			rc.CAData = cluster.CertificateAuthorityData
+			rc.CertData = authInfo.ClientCertificateData
+			rc.KeyData = authInfo.ClientKeyData
 
 			return rc, nil
 		}

--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -272,23 +272,23 @@ func expandApplicationSourceKustomizePatchTarget(in []interface{}) *application.
 	t := in[0].(map[string]interface{})
 
 	if group, ok := t["group"]; ok {
-		result.KustomizeResId.KustomizeGvk.Group = group.(string)
+		result.Group = group.(string)
 	}
 
 	if version, ok := t["version"]; ok {
-		result.KustomizeResId.KustomizeGvk.Version = version.(string)
+		result.Version = version.(string)
 	}
 
 	if kind, ok := t["kind"]; ok {
-		result.KustomizeResId.KustomizeGvk.Kind = kind.(string)
+		result.Kind = kind.(string)
 	}
 
 	if name, ok := t["name"]; ok {
-		result.KustomizeResId.Name = name.(string)
+		result.Name = name.(string)
 	}
 
 	if namespace, ok := t["namespace"]; ok {
-		result.KustomizeResId.Namespace = namespace.(string)
+		result.Namespace = namespace.(string)
 	}
 
 	if label_selector, ok := t["label_selector"]; ok {
@@ -834,11 +834,11 @@ func flattenApplicationSourceKustomize(as []*application.ApplicationSourceKustom
 				if p.Target != nil {
 					patch["target"] = []map[string]interface{}{
 						{
-							"group":               p.Target.KustomizeResId.KustomizeGvk.Group,
-							"version":             p.Target.KustomizeResId.KustomizeGvk.Version,
-							"kind":                p.Target.KustomizeResId.KustomizeGvk.Kind,
-							"name":                p.Target.KustomizeResId.Name,
-							"namespace":           p.Target.KustomizeResId.Namespace,
+							"group":               p.Target.Group,
+							"version":             p.Target.Version,
+							"kind":                p.Target.Kind,
+							"name":                p.Target.Name,
+							"namespace":           p.Target.Namespace,
 							"label_selector":      p.Target.LabelSelector,
 							"annotation_selector": p.Target.AnnotationSelector,
 						},

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -856,14 +856,14 @@ func expandApplicationMatchExpressions(mes []interface{}) []application.Applicat
 }
 
 func expandApplicationSetSyncPolicyApplicationsSyncPolicy(p string) (asp application.ApplicationsSyncPolicy) {
-	switch {
-	case p == "create-only":
+	switch p {
+	case "create-only":
 		asp = application.ApplicationsSyncPolicyCreateOnly
-	case p == "create-update":
+	case "create-update":
 		asp = application.ApplicationsSyncPolicyCreateUpdate
-	case p == "create-delete":
+	case "create-delete":
 		asp = application.ApplicationsSyncPolicyCreateDelete
-	case p == "sync":
+	case "sync":
 		asp = application.ApplicationsSyncPolicySync
 	}
 

--- a/argocd/structure_cluster.go
+++ b/argocd/structure_cluster.go
@@ -87,15 +87,15 @@ func expandClusterConfig(config interface{}) application.ClusterConfig {
 		for k, v := range tls[0].(map[string]interface{}) {
 			switch k {
 			case "ca_data":
-				clusterConfig.TLSClientConfig.CAData = []byte(v.(string))
+				clusterConfig.CAData = []byte(v.(string))
 			case "cert_data":
-				clusterConfig.TLSClientConfig.CertData = []byte(v.(string))
+				clusterConfig.CertData = []byte(v.(string))
 			case "key_data":
-				clusterConfig.TLSClientConfig.KeyData = []byte(v.(string))
+				clusterConfig.KeyData = []byte(v.(string))
 			case "insecure":
-				clusterConfig.TLSClientConfig.Insecure = v.(bool)
+				clusterConfig.Insecure = v.(bool)
 			case "server_name":
-				clusterConfig.TLSClientConfig.ServerName = v.(string)
+				clusterConfig.ServerName = v.(string)
 			}
 		}
 	}

--- a/argocd/structure_repository_certificate.go
+++ b/argocd/structure_repository_certificate.go
@@ -41,7 +41,8 @@ func expandRepositoryCertificate(d *schema.ResourceData) *application.Repository
 func flattenRepositoryCertificate(certificate *application.RepositoryCertificate, d *schema.ResourceData, ctx context.Context) error {
 	var r map[string]interface{}
 
-	if certificate.CertType == "ssh" {
+	switch certificate.CertType {
+	case "ssh":
 		r = map[string]interface{}{
 			"ssh": []map[string]string{
 				{
@@ -52,7 +53,7 @@ func flattenRepositoryCertificate(certificate *application.RepositoryCertificate
 				},
 			},
 		}
-	} else if certificate.CertType == "https" {
+	case "https":
 		r = map[string]interface{}{
 			"https": []map[string]string{
 				{


### PR DESCRIPTION
Migrates golangci-lint to v2.

Most of the config was migrated using `golangci-lint migrate`, some excludes have been added manually to keep the PR small.

I tried fixing the `SA1019` issue in `internal/types/pgp_public_key.go` but gave up after half an hour due to the complexity that came with it. Might be something we need to address in a separate issue.