### PR TITLE
fix: allow templated label values

### DIFF
--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -30,7 +30,7 @@ func resourceArgoCDApplication() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchema("applications.argoproj.io"),
-			"spec":     applicationSpecSchemaV4(false),
+			"spec":     applicationSpecSchemaV4(false, false),
 			"wait": {
 				Type:        schema.TypeBool,
 				Description: "Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will experience an expected timeout event if `wait = true`.",

--- a/argocd/schema_application.go
+++ b/argocd/schema_application.go
@@ -140,7 +140,7 @@ func applicationSpecSchemaV0() *schema.Schema {
 											Type:         schema.TypeMap,
 											Optional:     true,
 											Elem:         &schema.Schema{Type: schema.TypeString},
-											ValidateFunc: validateMetadataLabels,
+											ValidateFunc: validateMetadataLabels(false),
 										},
 										"common_annotations": {
 											Type:         schema.TypeMap,
@@ -520,7 +520,7 @@ func applicationSpecSchemaV1() *schema.Schema {
 											Type:         schema.TypeMap,
 											Optional:     true,
 											Elem:         &schema.Schema{Type: schema.TypeString},
-											ValidateFunc: validateMetadataLabels,
+											ValidateFunc: validateMetadataLabels(false),
 										},
 										"common_annotations": {
 											Type:         schema.TypeMap,
@@ -951,7 +951,7 @@ func applicationSpecSchemaV2() *schema.Schema {
 											Description:  "List of additional labels to add to rendered manifests.",
 											Optional:     true,
 											Elem:         &schema.Schema{Type: schema.TypeString},
-											ValidateFunc: validateMetadataLabels,
+											ValidateFunc: validateMetadataLabels(false),
 										},
 										"common_annotations": {
 											Type:         schema.TypeMap,
@@ -1232,7 +1232,7 @@ func applicationSpecSchemaV3() *schema.Schema {
 	return applicationSpecSchemaV2()
 }
 
-func applicationSpecSchemaV4(allOptional bool) *schema.Schema {
+func applicationSpecSchemaV4(allOptional, isAppSet bool) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		MinItems:    1,
@@ -1432,7 +1432,7 @@ func applicationSpecSchemaV4(allOptional bool) *schema.Schema {
 											Description:  "List of additional labels to add to rendered manifests.",
 											Optional:     true,
 											Elem:         &schema.Schema{Type: schema.TypeString},
-											ValidateFunc: validateMetadataLabels,
+											ValidateFunc: validateMetadataLabels(false),
 										},
 										"common_annotations": {
 											Type:         schema.TypeMap,
@@ -1784,7 +1784,7 @@ func applicationSpecSchemaV4(allOptional bool) *schema.Schema {
 											Description:  "Labels to apply to the namespace.",
 											Optional:     true,
 											Elem:         &schema.Schema{Type: schema.TypeString},
-											ValidateFunc: validateMetadataLabels,
+											ValidateFunc: validateMetadataLabels(isAppSet),
 										},
 									},
 								},

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -1033,7 +1033,7 @@ func applicationSetTemplateResource(allOptional bool) *schema.Resource {
 					},
 				},
 			},
-			"spec": applicationSpecSchemaV4(allOptional),
+			"spec": applicationSpecSchemaV4(allOptional, true),
 		},
 	}
 }

--- a/argocd/schema_cluster.go
+++ b/argocd/schema_cluster.go
@@ -1,8 +1,9 @@
 package argocd
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func clusterSchema() map[string]*schema.Schema {
@@ -226,7 +227,7 @@ func clusterSchema() map[string]*schema.Schema {
 						Description:  "Map of string keys and values that can be used to organize and categorize (scope and select) the cluster secret. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
 						Optional:     true,
 						Elem:         &schema.Schema{Type: schema.TypeString},
-						ValidateFunc: validateMetadataLabels,
+						ValidateFunc: validateMetadataLabels(false),
 					},
 				},
 			},

--- a/argocd/schema_metadata.go
+++ b/argocd/schema_metadata.go
@@ -37,7 +37,7 @@ func metadataFields(objectName string) map[string]*schema.Schema {
 			Description:  fmt.Sprintf("Map of string keys and values that can be used to organize and categorize (scope and select) the %s. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels", objectName),
 			Optional:     true,
 			Elem:         &schema.Schema{Type: schema.TypeString},
-			ValidateFunc: validateMetadataLabels,
+			ValidateFunc: validateMetadataLabels(false),
 		},
 		"name": {
 			Type:         schema.TypeString,

--- a/argocd/validators_test.go
+++ b/argocd/validators_test.go
@@ -4,7 +4,125 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func Test_validateMetadataLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		isAppSet bool
+		value    interface{}
+		key      string
+		wantWs   []string
+		wantEs   []error
+	}{
+		{
+			name:     "Valid labels",
+			isAppSet: false,
+			value: map[string]interface{}{
+				"valid-key": "valid-value",
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: nil,
+		},
+		{
+			name:     "Invalid label key",
+			isAppSet: false,
+			value: map[string]interface{}{
+				"Invalid Key!": "valid-value",
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: []error{
+				fmt.Errorf("metadata_labels (\"Invalid Key!\") name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
+			},
+		},
+		{
+			name:     "Invalid label value",
+			isAppSet: false,
+			value: map[string]interface{}{
+				"valid-key": "Invalid Value!",
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: []error{
+				fmt.Errorf("metadata_labels (\"Invalid Value!\") a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"),
+			},
+		},
+		{
+			name:     "Non-string label value",
+			isAppSet: false,
+			value: map[string]interface{}{
+				"valid-key": 123,
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: []error{
+				fmt.Errorf("metadata_labels.valid-key (123): Expected value to be string"),
+			},
+		},
+		{
+			name:     "Valid templated value for AppSet",
+			isAppSet: true,
+			value: map[string]interface{}{
+				"valid-key": "{{ valid-template }}",
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: nil,
+		},
+		{
+			name:     "Invalid templated value for non-AppSet",
+			isAppSet: false,
+			value: map[string]interface{}{
+				"valid-key": "{{ invalid-template }}",
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: []error{
+				fmt.Errorf("metadata_labels (\"{{ invalid-template }}\") a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"),
+			},
+		},
+		{
+			name:     "Empty label key",
+			isAppSet: false,
+			value: map[string]interface{}{
+				"": "valid-value",
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: []error{
+				fmt.Errorf("metadata_labels (\"\") name part must be non-empty"),
+				fmt.Errorf("metadata_labels (\"\") name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
+			},
+		},
+		{
+			name:     "Empty label value",
+			isAppSet: false,
+			value: map[string]interface{}{
+				"valid-key": "",
+			},
+			key:    "metadata_labels",
+			wantWs: nil,
+			wantEs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotWs, gotEs := validateMetadataLabels(tt.isAppSet)(tt.value, tt.key)
+
+			require.Equal(t, tt.wantWs, gotWs)
+			require.Equal(t, tt.wantEs, gotEs)
+		})
+	}
+}
 
 func Test_validateSSHPrivateKey(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
`validateMetadataLabels` ensures that labels are in a certain format. This works fine in most cases, except when this is used within appsets, which allow for labels to be templated. This adds a layer of indirection allowing for templated labels to be used, but only when an appset makes use of this feature.