### PR TITLE
feat: Support ApplicationSets in any Namespace

### DIFF
--- a/manifests/install/cluster-rbac.yml
+++ b/manifests/install/cluster-rbac.yml
@@ -16,6 +16,7 @@ rules:
       - argoproj.io
     resources:
       - applications
+      - applicationsets
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/install/patches/argocd-cmd-params-cm.yml
+++ b/manifests/install/patches/argocd-cmd-params-cm.yml
@@ -4,3 +4,5 @@ metadata:
   name: argocd-cmd-params-cm
 data:
   application.namespaces: mynamespace-*
+  applicationsetcontroller.enable.scm.providers: "false"
+  applicationsetcontroller.namespaces: "*"


### PR DESCRIPTION
The pull request addressing issue [#548](https://github.com/argoproj-labs/terraform-provider-argocd/issues/548) enhances the Terraform ArgoCD provider by enabling support for ApplicationSets across any namespace. This update allows users to manage ApplicationSets beyond the default argocd namespace.
