### PR TITLE
feat(appsets): add state upgrade logic for appsets in any namespace

### DIFF
--- a/argocd/resource_argocd_application_set.go
+++ b/argocd/resource_argocd_application_set.go
@@ -26,7 +26,15 @@ func resourceArgoCDApplicationSet() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchema("applicationsets.argoproj.io"),
-			"spec":     applicationSetSpecSchemaV0(),
+			"spec":     applicationSetSpecSchemaV1(),
+		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceArgoCDApplicationV1().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceArgoCDApplicationSetStateUpgradeV0,
+				Version: 0,
+			},
 		},
 	}
 }

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -140,12 +140,11 @@ func applicationSetSpecSchemaV0() *schema.Schema {
 }
 
 func applicationSetSpecSchemaV1() *schema.Schema {
-	// To support deploying applicationsets to non-default namespaces (aka project
-	// source namespaces), we need to do a state migration to ensure that the Id
-	// on existing resources is updated to include the namespace.
-	// For this to happen, we need to trigger a schema version upgrade on the
-	// application resource however, the schema of the application `spec` has
-	// changed from `v0`.
+	// To support deploying applicationsets to non-default namespaces we need to
+	// do a state migration to ensure that the Id on existing resources is
+	// updated to include the namespace. For this to happen, we need to trigger
+	// a schema version upgrade on the applicationset resource however, the
+	// schema of the applicationset `spec` has not changed from `v0`.
 	return applicationSetSpecSchemaV0()
 }
 

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -1,6 +1,9 @@
 package argocd
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -136,6 +139,16 @@ func applicationSetSpecSchemaV0() *schema.Schema {
 	}
 }
 
+func applicationSetSpecSchemaV1() *schema.Schema {
+	// To support deploying applicationsets to non-default namespaces (aka project
+	// source namespaces), we need to do a state migration to ensure that the Id
+	// on existing resources is updated to include the namespace.
+	// For this to happen, we need to trigger a schema version upgrade on the
+	// application resource however, the schema of the application `spec` has
+	// changed from `v0`.
+	return applicationSetSpecSchemaV0()
+}
+
 func applicationSetGeneratorSchemaV0() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
@@ -144,6 +157,18 @@ func applicationSetGeneratorSchemaV0() *schema.Schema {
 		MinItems:    1,
 		Elem:        generatorResourceV0(generatorSchemaLevel),
 	}
+}
+
+func resourceArgoCDApplicationSetStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	_metadata, ok := rawState["metadata"].([]interface{})
+	if !ok || len(_metadata) == 0 {
+		return nil, fmt.Errorf("failed to read metadata during state migration v0 to v1")
+	}
+
+	metadata := _metadata[0].(map[string]interface{})
+	rawState["id"] = fmt.Sprintf("%s:%s", metadata["name"].(string), metadata["namespace"].(string))
+
+	return rawState, nil
 }
 
 func generatorResourceV0(level int) *schema.Resource {


### PR DESCRIPTION
Adds a state migration to automatically update existing resources to use the new ID format. This should complete #548 and allow for a non-breaking change.

Most of the code was copied from #212 