### PR TITLE
chore: add ability to optionally filter tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,7 @@ ARGOCD_AUTH_USERNAME?=admin
 ARGOCD_AUTH_PASSWORD?=acceptancetesting
 ARGOCD_VERSION?=v3.0.0
 K3S_VERSION?=v1.31.6-k3s1
+TEST_FILTER?=
 
 export
 
@@ -26,13 +27,13 @@ fmt:
 	gofmt -s -w -e .
 
 test:
-	go test -v -cover -timeout=120s -parallel=4 ./...
+	go test -v -cover -timeout=120s -parallel=4 -run="$(TEST_FILTER)" ./...
 
 testacc:
-	TF_ACC=1 go test -v -cover -timeout 20m ./...
+	TF_ACC=1 go test -v -cover -timeout 20m -run="$(TEST_FILTER)" ./...
 
 testacc_testcontainers:
-	TF_ACC=1 USE_TESTCONTAINERS=true go test -v -cover -timeout 30m ./...
+	TF_ACC=1 USE_TESTCONTAINERS=true go test -v -cover -timeout 30m -run="$(TEST_FILTER)" ./...
 
 testacc_clean_env:
 	kind delete cluster --name argocd

--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -400,6 +400,11 @@ resource "argocd_cluster" "simple" {
 }
 
 func testAccArgoCDClusterTLSCertificate(t *testing.T, clusterName string) string {
+	// Skip if we're not in an acceptance test environment
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+
 	rc, err := getInternalRestConfig()
 	if err != nil {
 		t.Error(err)

--- a/argocd/resource_argocd_repository_certificate_test.go
+++ b/argocd/resource_argocd_repository_certificate_test.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -202,6 +203,11 @@ func TestAccArgoCDRepositoryCertificatesSSH_Allow_Random_Subtype(t *testing.T) {
 }
 
 func TestAccArgoCDRepositoryCertificatesSSH_WithApplication(t *testing.T) {
+	// Skip if we're not in an acceptance test environment
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+
 	appName := acctest.RandomWithPrefix("testacc")
 
 	subtypesKeys, err := getSshKeysForHost("private-git-repository")


### PR DESCRIPTION
In the various `Makefile` tasks, add an option to filter out tests if necessary. I also fixed a few tests which were failing when running unit tests where the config params require a k8s environment to be up and running.