### PR TITLE
chore: preload argocd before running testcontainer tests

### DIFF
--- a/internal/testhelpers/testcontainers.go
+++ b/internal/testhelpers/testcontainers.go
@@ -58,7 +58,7 @@ func SetupK3sWithArgoCD(ctx context.Context, argoCDVersion, k3sVersion string) (
 	// Pull and preload Argo CD image in k3s to reduce waiting time during the `waitForArgoCD` step.
 	argoCDImage := fmt.Sprintf("quay.io/argoproj/argocd:%s", argoCDVersion)
 
-	log.Println(fmt.Sprintf("Pre-pulling Argo CD image %s...", argoCDImage))
+	log.Printf("Pre-pulling Argo CD image %s...\n", argoCDImage)
 
 	// First, pull the image to ensure it exists locally
 	_, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{


### PR DESCRIPTION
While running this locally I got a few tests that were persistently failing. It turned out to be because pulling the argocd image was slow, timing out the test init. Now we ensure that the image is pulled before performing `kubectl wait`, so that we only need to wait for the pods to be ready.