### PR TITLE
fix: prevent deadlock

### DIFF
--- a/internal/provider/resource_repository.go
+++ b/internal/provider/resource_repository.go
@@ -195,10 +195,12 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	var updatedRepo *v1alpha1.Repository
+
 	func() {
 		// Keep mutex enclosed in a function to keep the lock scoped to it and to prevent deadlocking
 		sync.RepositoryMutex.Lock()
 		defer sync.RepositoryMutex.Unlock()
+
 		updatedRepo, err = r.si.RepositoryClient.UpdateRepository(
 			ctx,
 			&repository.RepoUpdateRequest{Repo: repo},


### PR DESCRIPTION
Fixes #710. While migrating from an older version using sdkv2 to terraform-plugin-framework may need to recalculate the computed attributes, it should definitely not deadlock in the meantime.

Added a test where we create a repository using `7.8.0`, and then update it using the current version of this provider. Whereas before this deadlocked, it now updates as intended, and once this initial migration update has been done there is no state diff afterwards.