### PR TITLE
feat: refine & update community standards

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,25 +9,13 @@
       "disableIp6tables": true // experienced issues with missing chains in ip6tables when creating kind clusters
     },
     // https://github.com/devcontainers/features/tree/main/src/terraform
-    "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.9.7" // omit for latest
-    },
+    "ghcr.io/devcontainers/features/terraform:1": {},
     // https://github.com/mpriscella/features/tree/main/src/kind
-    "ghcr.io/mpriscella/features/kind:1": {
-      "version": "v0.20.0" // omit for latest
-    },
+    "ghcr.io/mpriscella/features/kind:1": {},
     // https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube
-    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-      "version": "1.31.9"
-    },
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
     // https://github.com/rio/features/tree/main/src/kustomize
-    "ghcr.io/rio/features/kustomize:1": {},
-    // https://github.com/guiyomh/features/blob/main/src/goreleaser
-    "ghcr.io/guiyomh/features/goreleaser:0": {},
-    // https://github.com/audacioustux/devcontainers/tree/main/src/argo
-    "ghcr.io/audacioustux/devcontainers/argo:1": {
-      "argocd": "2.8.13" // omit if empty
-    }
+    "ghcr.io/rio/features/kustomize:1": {}
   },
   "forwardPorts": [
     8080 // the "hard-coded" port for forwarded argo-cd"

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,6 +3,7 @@ name: "\U0001F41B Bug Report"
 about: "If something isn't working as expected \U0001F914."
 title: ''
 labels: bug
+type: bug
 
 ---
 
@@ -30,8 +31,8 @@ If this issue appears to affect multiple resources, it may be an issue with Terr
 ### Terraform Configuration Files
 ```hcl
 # Copy-paste your Terraform configurations here - for large Terraform configs,
-# please use a service like Dropbox and share a link to the ZIP file. For
-# security, you can also encrypt the files using our GPG public key.
+# please use an online file storage service and share a link to the ZIP file. For
+# security, you can also encrypt the files using our GPG public release key.
 ```
 
 ### Debug Output

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Provider Slack Channel
+    url: https://cloud-native.slack.com/archives/C07PQF40SF8
+    about: Slack Channel to discuss on the CNCF Workspace

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,6 +3,7 @@ name: "\U0001F680 Feature Request"
 about: "I have a suggestion (and might want to implement myself \U0001F642)!"
 title: ''
 labels: enhancement
+type: feature
 
 ---
 
@@ -15,22 +16,17 @@ labels: enhancement
 <!-- Information about code formatting: https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code -->
 
 ```hcl
-# Copy-paste your Terraform configurations here - for large Terraform configs,
-# please use a service like Dropbox and share a link to the ZIP file. For
-# security, you can also encrypt the files using our GPG public key.
+# Copy-paste a potential Terraform configuration here - for large Terraform configs,
+# please use an online file storage service and share a link to the ZIP file. For
+# security, you can also encrypt the files using our GPG public release key.
 ```
 
 ### References
 <!-- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? -->
 
-Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
-
-<!-- Please keep this note for the community -->
 
 ### Community Note
-
+<!-- Please keep this note for the community -->
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
 * If you are interested in working on this issue or have submitted a pull request, please leave a comment
-
-<!-- Thank you for keeping this note for the community -->

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,26 @@
+**What type of PR is this?**
+
+[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
+[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )
+
+<!-- /kind bug -->
+<!-- /kind chore -->
+<!-- /kind cleanup -->
+<!-- /kind failing-test -->
+<!-- /kind enhancement -->
+<!-- /kind documentation -->
+<!-- /kind code-refactoring -->
+
+
+**What does this PR do / why we need it**:
+
+**Have you updated the necessary documentation?**
+
+* [ ] Documentation update is required by this PR.
+* [ ] Documentation has been updated.
+
+**Which issue(s) this PR fixes**:
+
+Fixes #?
+
+**How to test changes / Special notes to the reviewer**:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,11 +3,11 @@ version: 2
 builds:
   - env:
       - CGO_ENABLED=0
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
     targets:
       - darwin_arm64
       - darwin_amd64
@@ -19,12 +19,12 @@ builds:
       - windows_386
       - freebsd_amd64
       - freebsd_arm
-    binary: '{{ .ProjectName }}_v{{ .Version }}'
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-  - formats: [ 'zip' ]
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - formats: ["zip"]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum
@@ -37,7 +37,7 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  draft: true
+  draft: false
   disable: false
   github:
     owner: argoproj-labs
@@ -45,5 +45,5 @@ release:
 changelog:
   filters:
     exclude:
-      - '^docs:'
-      - '^chore'
+      - "^docs:"
+      - "^chore"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of conduct
+
+While this provider is not a [Cloud Native Computing Foundation](https://www.cncf.io/) (CNCF) project, it supports, endorses, and
+echoes the code of conduct presented by the CNCF. The CNCF code of conduct can be found
+[here](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Full credit goes to the CNCF project for
+establishing the linked code of conduct principles.
+
+Instances of behaviors that are not aligned with the values proposed by CNCF can be reported to the repository admins via Github's reporting feature.
+See [Reporting Abuse or Spam](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam) for details how to do so.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,43 @@
 
 Contributions are welcome! 
 
-## Dependency Management
+[![Contributors](https://img.shields.io/github/contributors/argoproj-labs/terraform-provider-argocd)](https://github.com/argoproj-labs/terraform-provider-argocd)
+[![Last commit](https://img.shields.io/github/last-commit/argoproj-labs/terraform-provider-argocd)](https://github.com/argoproj-labs/terraform-provider-argocd)
+[![Stars](https://img.shields.io/github/stars/argoproj-labs/terraform-provider-argocd)](https://github.com/argoproj-labs/hera/terraofrm-provider-argocd)
 
-### K8s version
-In our CI we test against a Kubernetes version that is supported by all Argo CD versions we support.
+## New Contributor Guide
 
-That version can be obtained when looking at [this table](https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#tested-versions) in the Argo CD documentation.
+If you are a new contributor this section aims to show you everything you need to get started.
 
-### Argo CD client-lib
+We especially welcome contributions to issues that are labeled with ["good-first-issue"](https://github.com/argoproj-labs/terraform-provider-argocd/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22)
+or
+["help-wanted"](https://github.com/argoproj-labs/terraform-provider-argocd/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22help%20wanted%22).
 
-Some dependencies we use are strictly aligned with the Argo CD client-lib that we use and should only be updated together:
-- github.com/argoproj/gitops-engine
-- k8s.io/*
+We also encourage contributions in the form of:
+- bug/crash reports
+- Answering questions on [Slack](https://cloud-native.slack.com/archives/C07PQF40SF8)
+- Posting your use-case for the provider on [Slack](https://cloud-native.slack.com/archives/C07PQF40SF8) / Blog Post
 
-Please don't update any of these dependencies without having discussed this first!
+### Setting up
 
-## Building
+To contribute to this Provider you need the following tools installed locally:
+* [Go](https://go.dev/doc/install) (1.24)
+* [GNU Make](https://www.gnu.org/software/make/)
+* [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
+* [Container runtime](https://java.testcontainers.org/supported_docker_environment/)
+* [Kind](https://kind.sigs.k8s.io) (optional)
+* [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
+
+#### Codespaces
+
+If you don't want to install tools locally you can use Github Codespaces to contribute to this project. We have a pre-configured codespace that should have all tools installed already:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/argoproj-labs/terraform-provider-argocd)
+
+## Building 
 
 1. `git clone` this repository and `cd` into its directory
-2. `make build` will trigger the Golang build
+2. `make build` will trigger the Golang build and place it's binary in `<git-repo-path>/bin/terraform-provider-argocd`
 
 The provided `GNUmakefile` defines additional commands generally useful during
 development, like for running tests, generating documentation, code formatting
@@ -28,19 +46,14 @@ and linting. Taking a look at its content is recommended.
 
 ## Testing
 
-The acceptance tests run against a disposable ArgoCD installation within a
-[Kind](https://github.com/kubernetes-sigs/kind) cluster. Other requirements are
-having a Docker daemon running and
-[Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
-installed.
+The acceptance tests run against a disposable ArgoCD installation within a containerized-K3s cluster. We are using [testcontainers](https://testcontainers.com) for this. If you have a [supported container runtime](https://java.testcontainers.org/supported_docker_environment/) installed you can simply run the tests using:
 
 ```sh
-make testacc_prepare_env
-make testacc
-make testacc_clean_env
+make testacc # to run all the Terraform tests
+make test # to only run helper unit tests (minority of the testcases)
 ```
 
-## Generating documentation
+## Documentation
 
 This provider uses [terraform-plugin-docs](https://github.com/hashicorp/terraform-plugin-docs/)
 to generate documentation and store it in the `docs/` directory.
@@ -50,10 +63,36 @@ and associate it with the release version. Read more about how this works on the
 
 Use `make generate` to ensure the documentation is regenerated with any changes.
 
-## Using a development build
+## Debugging
 
-If [running tests and acceptance tests](#testing) isn't enough, it's possible to
-set up a local terraform configuration to use a development builds of the
+We have some pre-made config to debug and run the provider using VSCode. If you are using another IDE take a look at [Hashicorp's Debug docs](https://developer.hashicorp.com/terraform/plugin/debugging#starting-a-provider-in-debug-mode) for instructions or adapt [.vscode/launch.json](.vscode/launch.json) for your IDE
+
+### Running the Terraform provider in debug mode (VSCode-specific)
+
+To use the preconfigured debug config in VS Code open the Debug tab and select the profile "Debug Terraform Provider". Set some breakpoints and then run this task. 
+
+Head to the debug console and copy the line where it says `TF_REATTACH_PROVIDERS` to the clipboard. 
+
+Open a terminal session and export the `TF_REATTACH_PROVIDERS` variable in this session. Every Terraform CLI command in this terminal session will then ensure it's using the provider already running inside VS Code and attach to it.
+
+Example of such a command:
+
+```console
+export TF_REATTACH_PROVIDERS='{"registry.terraform.io/argoproj-labs/argocd":{"Protocol":"grpc","ProtocolVersion":6,"Pid":2065,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/rj/_02y2jmn3k1bxx45wlzt2dkc0000gn/T/plugin193859953"}}}' 
+terraform apply -auto-approve # will use the provider running in debug-mode
+```
+
+**Note**: if the provider crashes or you restart the debug-session you have to re-export this variable to your terminal for the Terraform CLI to find the already running provider!
+
+### Running acceptance tests in debug mode (VSCode-specific)
+
+Open a test file, **hover** over a test function's name and then in the Debug tab of VSCode select "Debug selected Test". This will run the test you selected with the specific arguments required for Terraform to run the acceptance test.
+
+**Note**: You shouldn't use the builtin "Debug Test" profile that is shown when hovering over a test function since it doesn't contain the necessary configuration to find your Argo CD environment.
+
+## Run Terraform using a local build
+
+It's possible to set up a local terraform configuration to use a development build of the
 provider. This can be achieved by leveraging the Terraform CLI [configuration
 file development
 overrides](https://www.terraform.io/cli/config/config-file#development-overrides-for-provider-developers).
@@ -63,6 +102,9 @@ your
 [`${GOBIN}`](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies)
 (defaults to `${GOPATH}/bin` or `${HOME}/go/bin` if `${GOPATH}` is not set).
 Repeat this every time you make changes to the provider locally.
+
+Note: you can also use `make build` to place the binary into `<git-repo-path>/bin/terraform-provider-argocd` instead.
+
 
 Then write this config to a file:
 ```hcl filename="../reproduce/.terraformrc"
@@ -78,29 +120,23 @@ provider_installation {
 And lastly use the following environment variable in a terminal session to tell Terraform to use this file for picking up the development binary:
 ```console
 export TF_CLI_CONFIG_FILE=../.reproduce/.terraformrc
+terraform plan # will not use the local provider build 
 ```
 
 For further reference consult [HashiCorp's article](https://www.terraform.io/plugin/debugging#terraform-cli-development-overrides) about this topic.
 
-## Debugging
+## Dependency Management
 
-Hasicorp Docs: https://developer.hashicorp.com/terraform/plugin/debugging#starting-a-provider-in-debug-mode
+### K8s version
+In our CI we test against a Kubernetes version that is supported by all Argo CD versions we support.
 
-### Running the Terraform provider in debug mode
+That version can be obtained when looking at [this table](https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#tested-versions) in the Argo CD documentation.
 
-In VS Code open the Debug tab and select the profile "Debug Terraform Provider". Set some breakpoints and then run this task. 
+### Argo CD client-lib
 
-Then head to the debug console and copy the line where it says `TF_REATTACH_PROVIDERS` and copy it.
+Some dependencies we use are strictly aligned with the Argo CD client-lib that we use and should only be updated together:
+- github.com/argoproj/gitops-engine
+- k8s.io/*
 
-Now that your provider is running in debug-mode in VS Code, you can head to any terminal where you want to run a Terraform stack and prepend the terraform command with the copied text. The Terraform CLI will then ensure it's using the provider already running inside VS Code.
+Please **don't update** any of these dependencies without having discussed this first!
 
-### Running acceptance tests in debug mode
-
-Open a test file, hover over a test function name and in the Debug tab hit "Debug selected Test". You shouldn't use the builtin "Debug Test" profile that is shown when hovering over a test function since it doesn't contain the necessary configuration to find your Argo CD environment.
-
-## Troubleshooting during local development
-
-* **"too many open files":** Running all acceptance tests in parallel (the
-  default) may open a lot of files and sockets, therefore ensure your local
-  workstation [open files/sockets limits are tuned
-  accordingly](https://k6.io/docs/misc/fine-tuning-os).

--- a/README.md
+++ b/README.md
@@ -169,13 +169,6 @@ HashiCorps [replace-provider] docs. In summary, you can do the following:
 
 5. You have successfully migrated
 
-## Requirements
-
-* [Terraform](https://www.terraform.io/downloads) (>= 1.0)
-* [Go](https://go.dev/doc/install) (1.24)
-* [GNU Make](https://www.gnu.org/software/make/)
-* [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
-
 ## Credits
 
 * We would like to thank [Olivier Boukili] for creating this awesome Terraform provider and moving the project over to

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+# Provider release process
+
+Our release process relies on [Goreleaser](https://goreleaser.com) for automatically building provider binaries for all architectures, signing them and generating a Github release with the binaries attached.
+
+## Publishing a new version
+
+Once the maintainers are ready to publish a new version, they can create a new git tag starting with `v*` and following [semver](https://semver.org). Pushing this tag will trigger a Github action that runs goreleaser.
+
+They will find a new release with the appropriate version, changelog and attached artifacts on github, that was automatically marked as latest.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability 
+
+We have enabled the ability to privately report security issues through the  Security tab above.
+
+[Here are the details on how to file a new vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+
+A repository owner/maintainer will respond as fast as possible to coordinate confirmation of the issue and remediation.
+
+Thank you for helping to ensure this code stays secure!


### PR DESCRIPTION
This PR:
- updates devcontainer config to only contain the minimal requirements
- aligns issue templates to be a bit more consistent
- disables opening issues without an issue template
- updates the contributing guide to reflect current state of development
- adds the slack channel as option when opening a new issue
- autopublishes github releases from within goreleaser (Terraform picks up the tag, so no need to wait with the Github release)
- Adds a simple PR template
- Adds a Code of Conduct and links to the CCNF CoC
- Adds a security policy for vulnerability reporting
- Adds a releasing process documentation

I know it's a lot of changes for one PR, but I thought it's better than having to review a bunch of PRs with very small changes.