### PR TITLE
feat(provider): add server_name to override ArgoCD server pod selector for port forwarding

### DIFF
--- a/argocd/model_provider.go
+++ b/argocd/model_provider.go
@@ -31,6 +31,7 @@ type ArgoCDProviderConfig struct {
 	ServerAddr               types.String `tfsdk:"server_addr"`
 	PortForward              types.Bool   `tfsdk:"port_forward"`
 	PortForwardWithNamespace types.String `tfsdk:"port_forward_with_namespace"`
+	ServerName               types.String `tfsdk:"server_name"`
 	Kubernetes               []Kubernetes `tfsdk:"kubernetes"`
 
 	// Run ArgoCD API server locally
@@ -235,7 +236,11 @@ func (p ArgoCDProviderConfig) setPortForwardingOpts(ctx context.Context, opts *a
 		}
 
 		opts.ServerAddr = "localhost" // will be overwritten by ArgoCD module when we initialize the API client but needs to be set here to ensure we
-		opts.ServerName = "argocd-server"
+
+		opts.ServerName = getDefaultString(p.ServerName, "ARGOCD_SERVER_NAME")
+		if opts.ServerName == "" {
+			opts.ServerName = "argocd-server"
+		}
 
 		if opts.PortForwardNamespace == "" {
 			opts.PortForwardNamespace = "argocd"

--- a/argocd/model_provider_test.go
+++ b/argocd/model_provider_test.go
@@ -1,0 +1,63 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSetPortForwardingOpts_ServerName(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverName types.String
+		envValue   string
+		expected   string
+	}{
+		{
+			name:       "defaults to argocd-server when unset",
+			serverName: types.StringNull(),
+			expected:   "argocd-server",
+		},
+		{
+			name:       "uses explicit provider configuration",
+			serverName: types.StringValue("argocd-argo-cd-server"),
+			expected:   "argocd-argo-cd-server",
+		},
+		{
+			name:       "falls back to ARGOCD_SERVER_NAME environment variable",
+			serverName: types.StringNull(),
+			envValue:   "argocd-argo-cd-server",
+			expected:   "argocd-argo-cd-server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv("ARGOCD_SERVER_NAME", tt.envValue)
+			}
+
+			p := ArgoCDProviderConfig{
+				PortForward: types.BoolValue(true),
+				ServerName:  tt.serverName,
+			}
+
+			opts := &apiclient.ClientOptions{PortForward: true}
+
+			enabled, diags := p.setPortForwardingOpts(context.Background(), opts)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags.Errors())
+			}
+
+			if !enabled {
+				t.Fatal("expected port forwarding to be enabled")
+			}
+
+			if opts.ServerName != tt.expected {
+				t.Errorf("expected ServerName %q, got %q", tt.expected, opts.ServerName)
+			}
+		})
+	}
+}

--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -120,6 +120,11 @@ func Provider() *schema.Provider {
 				Description: "Namespace name which should be used for port forwarding.",
 				Optional:    true,
 			},
+			"server_name": {
+				Type:        schema.TypeString,
+				Description: "Name of the ArgoCD API server; set this when the server's name label differs from the default (`argocd-server`), for example when installed via a Helm chart that renames the component. Only relevant when `port_forward = true` or `port_forward_with_namespace` is set. Can be set through the `ARGOCD_SERVER_NAME` environment variable.",
+				Optional:    true,
+			},
 			"headers": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -270,6 +275,7 @@ func argoCDProviderConfigFromResourceData(ctx context.Context, d *schema.Resourc
 		PortForward:              getBoolFromResourceData(d, "port_forward"),
 		PortForwardWithNamespace: getStringFromResourceData(d, "port_forward_with_namespace"),
 		ServerAddr:               getStringFromResourceData(d, "server_addr"),
+		ServerName:               getStringFromResourceData(d, "server_name"),
 		UseLocalConfig:           getBoolFromResourceData(d, "use_local_config"),
 		UserAgent:                getStringFromResourceData(d, "user_agent"),
 		Username:                 getStringFromResourceData(d, "username"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,15 @@ provider "argocd" {
   }
 }
 
+# Unexposed ArgoCD API - using port-forwarding against an ArgoCD installation
+# whose server component was renamed (e.g. by the Bitnami Helm chart), which
+# requires overriding the pod selector name used to find it.
+provider "argocd" {
+  auth_token   = "1234..."
+  port_forward = true
+  server_name  = "argocd-argo-cd-server"
+}
+
 # Unexposed ArgoCD API - using `core` to run ArgoCD server locally and
 # communicate directly with the Kubernetes API.
 provider "argocd" {
@@ -100,6 +109,7 @@ provider "argocd" {
 - `port_forward` (Boolean) Connect to a random argocd-server port using port forwarding.
 - `port_forward_with_namespace` (String) Namespace name which should be used for port forwarding.
 - `server_addr` (String) ArgoCD server address with port. Can be set through the `ARGOCD_SERVER` environment variable.
+- `server_name` (String) Name of the ArgoCD API server; set this when the server's name label differs from the default (`argocd-server`), for example when installed via a Helm chart that renames the component. Only relevant when `port_forward = true` or `port_forward_with_namespace` is set. Can be set through the `ARGOCD_SERVER_NAME` environment variable.
 - `use_local_config` (Boolean) Use the authentication settings found in the local config file. Useful when you have previously logged in using SSO. Conflicts with `auth_token`, `username` and `password`.
 - `user_agent` (String) User-Agent request header override.
 - `username` (String) Authentication username. Can be set through the `ARGOCD_AUTH_USERNAME` environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -36,6 +36,15 @@ provider "argocd" {
   }
 }
 
+# Unexposed ArgoCD API - using port-forwarding against an ArgoCD installation
+# whose server component was renamed (e.g. by the Bitnami Helm chart), which
+# requires overriding the pod selector name used to find it.
+provider "argocd" {
+  auth_token   = "1234..."
+  port_forward = true
+  server_name  = "argocd-argo-cd-server"
+}
+
 # Unexposed ArgoCD API - using `core` to run ArgoCD server locally and
 # communicate directly with the Kubernetes API.
 provider "argocd" {

--- a/internal/provider/model_provider.go
+++ b/internal/provider/model_provider.go
@@ -31,6 +31,7 @@ type ArgoCDProviderConfig struct {
 	ServerAddr               types.String `tfsdk:"server_addr"`
 	PortForward              types.Bool   `tfsdk:"port_forward"`
 	PortForwardWithNamespace types.String `tfsdk:"port_forward_with_namespace"`
+	ServerName               types.String `tfsdk:"server_name"`
 	Kubernetes               []Kubernetes `tfsdk:"kubernetes"`
 
 	// Run ArgoCD API server locally
@@ -235,7 +236,11 @@ func (p ArgoCDProviderConfig) setPortForwardingOpts(ctx context.Context, opts *a
 		}
 
 		opts.ServerAddr = "localhost" // will be overwritten by ArgoCD module when we initialize the API client but needs to be set here to ensure we
-		opts.ServerName = "argocd-server"
+
+		opts.ServerName = getDefaultString(p.ServerName, "ARGOCD_SERVER_NAME")
+		if opts.ServerName == "" {
+			opts.ServerName = "argocd-server"
+		}
 
 		if opts.PortForwardNamespace == "" {
 			opts.PortForwardNamespace = "argocd"

--- a/internal/provider/model_provider_test.go
+++ b/internal/provider/model_provider_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apiclient"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSetPortForwardingOpts_ServerName(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverName types.String
+		envValue   string
+		expected   string
+	}{
+		{
+			name:       "defaults to argocd-server when unset",
+			serverName: types.StringNull(),
+			expected:   "argocd-server",
+		},
+		{
+			name:       "uses explicit provider configuration",
+			serverName: types.StringValue("argocd-argo-cd-server"),
+			expected:   "argocd-argo-cd-server",
+		},
+		{
+			name:       "falls back to ARGOCD_SERVER_NAME environment variable",
+			serverName: types.StringNull(),
+			envValue:   "argocd-argo-cd-server",
+			expected:   "argocd-argo-cd-server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv("ARGOCD_SERVER_NAME", tt.envValue)
+			}
+
+			p := ArgoCDProviderConfig{
+				PortForward: types.BoolValue(true),
+				ServerName:  tt.serverName,
+			}
+
+			opts := &apiclient.ClientOptions{PortForward: true}
+
+			enabled, diags := p.setPortForwardingOpts(context.Background(), opts)
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags.Errors())
+			}
+
+			if !enabled {
+				t.Fatal("expected port forwarding to be enabled")
+			}
+
+			if opts.ServerName != tt.expected {
+				t.Errorf("expected ServerName %q, got %q", tt.expected, opts.ServerName)
+			}
+		})
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -74,6 +74,10 @@ func (p *ArgoCDProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 				Description: "Namespace name which should be used for port forwarding.",
 				Optional:    true,
 			},
+			"server_name": schema.StringAttribute{
+				Description: "Name of the ArgoCD API server; set this when the server's name label differs from the default (`argocd-server`), for example when installed via a Helm chart that renames the component. Only relevant when `port_forward = true` or `port_forward_with_namespace` is set. Can be set through the `ARGOCD_SERVER_NAME` environment variable.",
+				Optional:    true,
+			},
 			"use_local_config": schema.BoolAttribute{
 				Description: "Use the authentication settings found in the local config file. Useful when you have previously logged in using SSO. Conflicts with `auth_token`, `username` and `password`.",
 				Optional:    true,


### PR DESCRIPTION
/kind enhancement

Motivation:
When using port_forward or port_forward_with_namespace, the provider
locates the ArgoCD API server pod using a hardcoded label selector value
of "argocd-server". Installations that rename this component (e.g. the
Bitnami Helm chart, which names it argocd-argo-cd-server) fail with
"cannot find pod with selector: [app.kubernetes.io/name=argocd-server]"
and have no way to work around it, since the value was never threaded
through to the underlying apiclient.ClientOptions.ServerName field that
the upstream argocd CLI already exposes via --server-name /
ARGOCD_SERVER_NAME (argoproj-labs/terraform-provider-argocd#555).

Approach:
Add an optional server_name provider attribute (mirrored in both the
SDKv2 schema in argocd/provider.go and the terraform-plugin-framework
schema in internal/provider/provider.go, which must stay in sync since
both are combined via tf6muxserver). setPortForwardingOpts in both
model_provider.go files now resolves ServerName from the explicit
attribute, then the ARGOCD_SERVER_NAME environment variable (matching
the upstream CLI's own env var), falling back to the previous
"argocd-server" default when neither is set. Existing configurations
are unaffected.

Validation:
- go build ./...
- USE_TESTCONTAINERS=false go test ./... (unit tests; this sandbox has
  no container runtime, so the Docker-based K3s+ArgoCD acceptance suite
  used by `make testacc` could not be run here)
- Added argocd/model_provider_test.go and
  internal/provider/model_provider_test.go, unit-testing
  setPortForwardingOpts's ServerName resolution for: unset (defaults to
  "argocd-server"), explicit provider config, and the ARGOCD_SERVER_NAME
  env var fallback. Confirmed these tests fail against the prior
  hardcoded implementation and pass against this change.
- Manually verified (via a throwaway test invoking the muxed provider's
  GetProviderSchema) that the SDKv2 and framework schemas remain
  compatible with the new attribute present in both.

Documentation has been updated (docs/index.md, examples/provider/provider.tf).

Fixes #555

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>