### PR TITLE
test(project): cover optional destination/source_repos in expandProject

### DIFF
--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -1875,6 +1875,55 @@ resource "argocd_project" "empty_repos" {
 	`, name)
 }
 
+// TestAccArgoCDProject_NoDestinationsOrSourceRepos tests that a project can be
+// created with no "destination" blocks and no "source_repos" entries at all,
+// which is how a project is set up to be used as a global project for other
+// projects to inherit settings from (see
+// https://github.com/argoproj-labs/terraform-provider-argocd/issues/623).
+func TestAccArgoCDProject_NoDestinationsOrSourceRepos(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-acc-global")
+	config := testAccArgoCDProjectWithNoDestinationsOrSourceRepos(name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_project.global", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("argocd_project.global", "spec.0.destination.#", "0"),
+					resource.TestCheckResourceAttr("argocd_project.global", "spec.0.source_repos.#", "0"),
+				),
+			},
+			{
+				// Apply the same configuration again to verify no drift
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccArgoCDProjectWithNoDestinationsOrSourceRepos(name string) string {
+	return fmt.Sprintf(`
+resource "argocd_project" "global" {
+  metadata {
+    name      = "%s"
+    namespace = "argocd"
+  }
+
+  spec {
+    description = "global project with no destinations or source repos"
+  }
+}
+	`, name)
+}
+
 // TestAccArgoCDProject_EmptyRoleGroups tests that empty groups list in roles
 // doesn't cause "Provider produced inconsistent result after apply" error.
 func TestAccArgoCDProject_EmptyRoleGroups(t *testing.T) {

--- a/internal/provider/resource_project_unit_test.go
+++ b/internal/provider/resource_project_unit_test.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExpandProject_OptionalDestinationAndSourceRepos ensures that an
+// argocd_project can be expanded without any "destination" blocks or
+// "source_repos" entries, e.g. for use as a global project to inherit
+// settings from (see https://github.com/argoproj-labs/terraform-provider-argocd/issues/623).
+func TestExpandProject_OptionalDestinationAndSourceRepos(t *testing.T) {
+	t.Parallel()
+
+	data := &projectModel{
+		Metadata: []objectMeta{
+			{
+				Name: types.StringValue("global"),
+			},
+		},
+		Spec: []projectSpecModel{
+			{
+				Description: types.StringValue("global project with no destinations or source repos"),
+			},
+		},
+	}
+
+	objectMeta, spec, diags := expandProject(context.Background(), data)
+
+	require.False(t, diags.HasError(), "expandProject should not error when destination and source_repos are omitted")
+	assert.Equal(t, "global", objectMeta.Name)
+	assert.Empty(t, spec.Destinations)
+	assert.Empty(t, spec.SourceRepos)
+}

--- a/internal/provider/resource_project_unit_test.go
+++ b/internal/provider/resource_project_unit_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -29,7 +28,7 @@ func TestExpandProject_OptionalDestinationAndSourceRepos(t *testing.T) {
 		},
 	}
 
-	objectMeta, spec, diags := expandProject(context.Background(), data)
+	objectMeta, spec, diags := expandProject(t.Context(), data)
 
 	require.False(t, diags.HasError(), "expandProject should not error when destination and source_repos are omitted")
 	assert.Equal(t, "global", objectMeta.Name)


### PR DESCRIPTION
Motivation:
Issue reports that argocd_project requires at least one "destination"
block and non-empty source_repos, which blocks the "global project"
pattern (a project with no destinations/source_repos, meant to be
inherited from). Auditing the current argocd_project implementation
(internal/provider, migrated from the legacy SDKv2 resource by a prior
project/tokens migration, with empty-list handling further fixed by a
later change) shows this is already supported: the "destination"
schema block has no SizeAtLeast/MinItems validator, "source_repos" is
a plain optional ListAttribute, and expandProject() simply ranges over
both fields, producing an empty/nil result with no error when they are
omitted. No code path enforces a minimum count. This was apparently
resolved by the framework migration without ever being linked back to
this issue.

Approach:
Since there is no actual defect to fix in the current code, this adds
a regression-guarding unit test, TestExpandProject_OptionalDestinationAndSourceRepos,
that calls expandProject() directly with a projectModel containing no
Destination and no SourceRepos, and asserts it succeeds with an empty
result. This locks in the already-correct behavior described in the
issue and prevents a future change (e.g. reintroducing a SizeAtLeast(1)
validator) from silently breaking it again. No production code is
changed.

Validation:
- `go build ./...` succeeds.
- This package's TestMain (internal/testhelpers/suite.go) normally
  spins up a real K3s+ArgoCD via testcontainers for every test in the
  package; Docker is not available in this environment, so the
  documented `make test`/`make testacc` targets could not be run here.
  The suite explicitly supports bypassing that setup via
  USE_TESTCONTAINERS=false, which was used to run this pure unit test:
  `USE_TESTCONTAINERS=false go test ./internal/provider/... -run 'TestExpandProject_OptionalDestinationAndSourceRepos' -v`
  -> PASS.
- To confirm the test is meaningful, the old "at least one destination"
  requirement was temporarily reintroduced in expandProject() (an
  early AddError when len(Destination) == 0); the same test command
  then FAILED as expected. The temporary change was reverted (verified
  via `git diff` showing no changes outside the new test file) and the
  test passes again.
- The full acceptance suite (make testacc), which requires Docker, was
  not run in this environment.

Report: https://github.com/argoproj-labs/terraform-provider-argocd/issues/623
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #623