### PR TITLE
fix: prevent panic on nil value_files entry in helm source expansion

### DIFF
--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -328,7 +328,9 @@ func expandApplicationSourceHelm(in []interface{}) *application.ApplicationSourc
 	if a, ok := in[0].(map[string]interface{}); ok {
 		if v, ok := a["value_files"]; ok {
 			for _, vf := range v.([]interface{}) {
-				result.ValueFiles = append(result.ValueFiles, vf.(string))
+				if s, ok := vf.(string); ok {
+					result.ValueFiles = append(result.ValueFiles, s)
+				}
 			}
 		}
 

--- a/argocd/structure_application_test.go
+++ b/argocd/structure_application_test.go
@@ -1,0 +1,23 @@
+package argocd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExpandApplicationSourceHelmNilValueFile(t *testing.T) {
+	t.Parallel()
+
+	input := []interface{}{
+		map[string]interface{}{
+			"value_files": []interface{}{"values.yaml", nil},
+		},
+	}
+
+	result := expandApplicationSourceHelm(input)
+
+	expected := []string{"values.yaml"}
+	if !reflect.DeepEqual(result.ValueFiles, expected) {
+		t.Fatalf("expected ValueFiles %v, got %v", expected, result.ValueFiles)
+	}
+}


### PR DESCRIPTION
Motivation:
expandApplicationSourceHelm unconditionally type-asserts every element
of spec.source.helm.value_files to string. When an element is nil, the
unchecked assertion panics with "interface conversion: interface {} is
nil, not string", crashing the provider during apply. This exact panic,
at argocd/structure_application.go:331, was reported against v7.10.1
by a user whose argocd_application relied on depends_on plus a
value_files list built from file(), and it caused the plan to fail
with a stack trace pointing at this line.

Approach:
Change the value_files loop to use the "value, ok" form of the type
assertion and skip any element that isn't a string, instead of
panicking. This mirrors the soft-guard idiom ("if v, ok := ...; ok")
already used for every other optional field in this function, so a
stray nil list entry (a schema/SDK artifact, not meaningful user data)
is dropped rather than crashing the provider.

Validation:
Added TestExpandApplicationSourceHelmNilValueFile, which calls
expandApplicationSourceHelm with a value_files list containing
["values.yaml", nil]. Verified this test panics with the exact error
from the report against the old code, and passes against the fix.

Ran:
  USE_TESTCONTAINERS=false go test ./argocd/... -run TestExpandApplicationSourceHelmNilValueFile -v
  USE_TESTCONTAINERS=false go test -v -cover -timeout=120s -parallel=4 ./argocd/...
  go build ./...
  golangci-lint run ./argocd/...
All passed; golangci-lint reports the same 50 pre-existing goconst
warnings with or without this change, so nothing new was introduced.

Not run: this repo's acceptance test suite (make testacc) requires a
live kind/K3s cluster and the Terraform CLI, neither of which is
available in this environment, and `make generate` requires the
Terraform CLI as well. This change touches only expansion logic in
structure_application.go (no schema changes), so generated docs
should be unaffected, but that was not independently verified here.

Report: https://github.com/argoproj-labs/terraform-provider-argocd/issues/711
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #711