### PR TITLE
fix(application): avoid nil pointer dereference reading sync policy automated fields

### DIFF
--- a/internal/provider/model_application.go
+++ b/internal/provider/model_application.go
@@ -928,9 +928,9 @@ func newApplicationSyncPolicyAutomated(spa *v1alpha1.SyncPolicyAutomated) *appli
 	}
 
 	return &applicationSyncPolicyAutomated{
-		AllowEmpty: types.BoolValue(*spa.AllowEmpty),
-		Prune:      types.BoolValue(*spa.Prune),
-		SelfHeal:   types.BoolValue(*spa.SelfHeal),
+		AllowEmpty: types.BoolValue(spa.GetAllowEmpty()),
+		Prune:      types.BoolValue(spa.GetPrune()),
+		SelfHeal:   types.BoolValue(spa.GetSelfHeal()),
 	}
 }
 

--- a/internal/provider/model_application_test.go
+++ b/internal/provider/model_application_test.go
@@ -1,0 +1,49 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+// A running application's SyncPolicy.Automated fields (Prune, SelfHeal,
+// AllowEmpty) are *bool and are frequently nil when not explicitly set by
+// the user, e.g. right after an out-of-band sync triggered outside Terraform.
+// newApplicationSyncPolicyAutomated must not dereference them directly.
+func TestNewApplicationSyncPolicyAutomated_NilFields(t *testing.T) {
+	t.Parallel()
+
+	spa := &v1alpha1.SyncPolicyAutomated{}
+
+	assert.NotPanics(t, func() {
+		result := newApplicationSyncPolicyAutomated(spa)
+
+		assert.False(t, result.AllowEmpty.ValueBool())
+		assert.False(t, result.Prune.ValueBool())
+		assert.False(t, result.SelfHeal.ValueBool())
+	})
+}
+
+func TestNewApplicationSyncPolicyAutomated_SetFields(t *testing.T) {
+	t.Parallel()
+
+	allowEmpty, prune, selfHeal := true, true, true
+	spa := &v1alpha1.SyncPolicyAutomated{
+		AllowEmpty: &allowEmpty,
+		Prune:      &prune,
+		SelfHeal:   &selfHeal,
+	}
+
+	result := newApplicationSyncPolicyAutomated(spa)
+
+	assert.True(t, result.AllowEmpty.ValueBool())
+	assert.True(t, result.Prune.ValueBool())
+	assert.True(t, result.SelfHeal.ValueBool())
+}
+
+func TestNewApplicationSyncPolicyAutomated_Nil(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, newApplicationSyncPolicyAutomated(nil))
+}


### PR DESCRIPTION
Motivation:
The data.argocd_application data source (and the application resource's
read path) crashes the provider process ("Plugin did not respond") when an
application's spec.syncPolicy.automated block has any of its Prune,
SelfHeal, or AllowEmpty fields unset on the ArgoCD server side. This is a
very common situation: these three fields are independently optional, and
a user (or ArgoCD itself) may set only one or two of them.

The regression was introduced when the vendored argo-cd v3 client was
bumped to add v3.4 support. SyncPolicyAutomated.{Prune,SelfHeal,AllowEmpty}
changed from plain bool to *bool upstream, and
newApplicationSyncPolicyAutomated started dereferencing them
unconditionally (*spa.Prune, *spa.SelfHeal, *spa.AllowEmpty), causing a nil
pointer dereference panic whenever one of them is nil.

Approach:
Use the nil-safe GetPrune()/GetSelfHeal()/GetAllowEmpty() accessor methods
that the upstream argo-cd v1alpha1.SyncPolicyAutomated type already
provides for exactly this purpose (they return false when the receiver or
the field is nil), instead of dereferencing the pointers directly. This
restores the pre-regression behavior, where these fields defaulted to
false when unset.

Validation:
Added a targeted unit test
(internal/provider/model_application_test.go) that constructs a
SyncPolicyAutomated with all three pointer fields left nil and calls
newApplicationSyncPolicyAutomated directly. Confirmed this test panics
with "invalid memory address or nil pointer dereference" at the
now-fixed line against the pre-fix code, and passes cleanly after the
fix. Ran:
  USE_TESTCONTAINERS=false go test ./internal/provider/... -run TestNewApplicationSyncPolicyAutomated -v
and the broader:
  USE_TESTCONTAINERS=false go test ./internal/...
both pass. Also ran `go build ./...`, `go vet ./...`, and
`golangci-lint run ./internal/provider/...` (0 new issues; a handful of
pre-existing goconst warnings in unrelated lines/files are unchanged by
this diff).

Not run: this repo's `make testacc` acceptance suite (spins up a live
ArgoCD server in a K3s testcontainer) and `make generate`, because Docker
and the terraform CLI are not available in this environment. The change
only affects a value-conversion helper and does not touch any schema
definitions, so `make generate` should produce no diff, but that was not
verified by actually running it.

Report: https://github.com/argoproj-labs/terraform-provider-argocd/issues/919
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #919